### PR TITLE
[MOBILE-584] Add notification management

### DIFF
--- a/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
+++ b/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
@@ -13,6 +13,7 @@ import com.urbanairship.util.DateUtils
 import com.urbanairship.util.UAStringUtil
 import com.urbanairship.widget.UAWebView
 import com.urbanairship.widget.UAWebViewClient
+import java.lang.NumberFormatException
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
@@ -21,8 +22,6 @@ import io.flutter.plugin.common.PluginRegistry.Registrar
 import io.flutter.plugin.common.StandardMessageCodec
 import io.flutter.plugin.platform.PlatformView
 import io.flutter.plugin.platform.PlatformViewFactory
-import java.lang.NumberFormatException
-
 
 class InboxMessageViewFactory(private val registrar: Registrar) : PlatformViewFactory(StandardMessageCodec.INSTANCE) {
     override fun create(context: Context, viewId: Int, arguments: Any?): PlatformView {
@@ -214,11 +213,10 @@ class AirshipPlugin : MethodCallHandler {
                 val statusBarNotifications = notificationManager.activeNotifications
 
                 for (statusBarNotification in statusBarNotifications) {
-
-                    val notification = HashMap<String, Any>()
-                    notification.put("notification_id", statusBarNotification.id.toString())
-
-                    notifications.add(notification)
+                    var message = Utils.shared.messageFromNotification(statusBarNotification)
+                    val tag = statusBarNotification.tag ?: ""
+                    val id = statusBarNotification.id.toString()
+                    notifications.add(Utils.shared.notificationObject(message, tag, id))
                 }
                 result.success(notifications)
             } else {

--- a/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
+++ b/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
@@ -1,12 +1,16 @@
 package com.airship.flutter
 
+import android.app.NotificationManager
 import android.content.Context
 import android.view.View
+import android.os.Build
+import androidx.core.app.NotificationManagerCompat
 import com.urbanairship.UAirship
 import com.urbanairship.analytics.CustomEvent
 import com.urbanairship.json.JsonMap
 import com.urbanairship.json.JsonValue
 import com.urbanairship.util.DateUtils
+import com.urbanairship.util.UAStringUtil
 import com.urbanairship.widget.UAWebView
 import com.urbanairship.widget.UAWebViewClient
 import io.flutter.plugin.common.MethodCall
@@ -17,6 +21,7 @@ import io.flutter.plugin.common.PluginRegistry.Registrar
 import io.flutter.plugin.common.StandardMessageCodec
 import io.flutter.plugin.platform.PlatformView
 import io.flutter.plugin.platform.PlatformViewFactory
+import java.lang.NumberFormatException
 
 
 class InboxMessageViewFactory(private val registrar: Registrar) : PlatformViewFactory(StandardMessageCodec.INSTANCE) {
@@ -78,6 +83,9 @@ class AirshipPlugin : MethodCallHandler {
             "getChannelId" -> getChannelId(result)
             "setUserNotificationsEnabled" -> setUserNotificationsEnabled(call, result)
             "getUserNotificationsEnabled" -> getUserNotificationsEnabled(result)
+            "clearNotification" -> clearNotification(call, result)
+            "clearNotifications" -> clearNotifications(result)
+            "getActiveNotifications" -> getActiveNotifications(result)
             "addTags" -> addTags(call, result)
             "addEvent" -> addEvent(call, result)
             "removeTags" -> removeTags(call, result)
@@ -196,6 +204,64 @@ class AirshipPlugin : MethodCallHandler {
 
     private fun getUserNotificationsEnabled(result: Result) {
         result.success(UAirship.shared().pushManager.userNotificationsEnabled)
+    }
+
+    private fun getActiveNotifications(result: Result) =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                val notifications = arrayListOf<Map<String, Any>>()
+
+                val notificationManager = UAirship.getApplicationContext().getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+                val statusBarNotifications = notificationManager.activeNotifications
+
+                for (statusBarNotification in statusBarNotifications) {
+
+                    val notification = HashMap<String, Any>()
+                    notification.put("notification_id", statusBarNotification.id.toString())
+
+                    notifications.add(notification)
+                }
+                result.success(notifications)
+            } else {
+                result.error("UNSUPPORTED", "Getting active notifications is only supported on Marshmallow and newer devices.", null)
+            }
+
+    private fun clearNotification(call: MethodCall, result: Result) {
+        val identifier = call.arguments as String
+
+        if (UAStringUtil.isEmpty(identifier)) {
+            return;
+        }
+
+        val parts = identifier.split(":", ignoreCase = true, limit = 2)
+        if (parts.size == 0) {
+            return;
+        }
+
+        var tag = String()
+        var id = 0
+
+        try {
+            id = (parts[0]).toInt();
+        } catch (e: NumberFormatException) {
+            return;
+        }
+
+        if (parts.size == 2) {
+            tag = parts[1];
+        }
+
+        if (tag == "") {
+            NotificationManagerCompat.from(UAirship.getApplicationContext()).cancel(null, id);
+        } else {
+            NotificationManagerCompat.from(UAirship.getApplicationContext()).cancel(tag, id);
+        }
+
+        result.success(true)
+    }
+
+    private fun clearNotifications(result: Result) {
+        NotificationManagerCompat.from(UAirship.getApplicationContext()).cancelAll();
+        result.success(true)
     }
 
     fun getChannelId(result: Result) {

--- a/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
+++ b/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
@@ -207,13 +207,13 @@ class AirshipPlugin : MethodCallHandler {
 
     private fun getActiveNotifications(result: Result) =
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                val notifications = arrayListOf<Map<String, Any>>()
+                val notifications = arrayListOf<Map<String, Any?>>()
 
                 val notificationManager = UAirship.getApplicationContext().getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
                 val statusBarNotifications = notificationManager.activeNotifications
 
                 for (statusBarNotification in statusBarNotifications) {
-                    var message = Utils.shared.messageFromNotification(statusBarNotification)
+                    var message = statusBarNotification.pushMessage()
                     val tag = statusBarNotification.tag ?: ""
                     val id = statusBarNotification.id.toString()
                     notifications.add(Utils.shared.notificationObject(message, tag, id))

--- a/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
+++ b/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
@@ -227,11 +227,13 @@ class AirshipPlugin : MethodCallHandler {
         val identifier = call.arguments as String
 
         if (UAStringUtil.isEmpty(identifier)) {
+            result.error("InvalidIdentifierFormat", "Unable to clear notification", null)
             return;
         }
 
         val parts = identifier.split(":", ignoreCase = true, limit = 2)
         if (parts.size == 0) {
+            result.error("InvalidIdentifierFormat", "Unable to clear notification", null)
             return;
         }
 
@@ -241,6 +243,7 @@ class AirshipPlugin : MethodCallHandler {
         try {
             id = (parts[0]).toInt();
         } catch (e: NumberFormatException) {
+            result.error("InvalidIdentifierFormat", "Unable to clear notification", null)
             return;
         }
 

--- a/android/src/main/kotlin/com/airship/flutter/Extensions.kt
+++ b/android/src/main/kotlin/com/airship/flutter/Extensions.kt
@@ -56,7 +56,6 @@ fun CustomEvent.Builder.parseProperties(map:HashMap<String, Any>) {
 
 @RequiresApi(Build.VERSION_CODES.KITKAT)
 fun StatusBarNotification.pushMessage(): PushMessage {
-
     val extras = this.notification.extras ?: return PushMessage(Bundle())
 
     val pushBundle = extras.getBundle(PUSH_MESSAGE_BUNDLE_EXTRA)

--- a/android/src/main/kotlin/com/airship/flutter/Extensions.kt
+++ b/android/src/main/kotlin/com/airship/flutter/Extensions.kt
@@ -1,8 +1,13 @@
 package com.airship.flutter
 
+import android.os.Build
+import android.os.Bundle
+import android.service.notification.StatusBarNotification
+import androidx.annotation.RequiresApi
 import com.urbanairship.analytics.CustomEvent
 import com.urbanairship.json.JsonMap
 import com.urbanairship.push.NotificationInfo
+import com.urbanairship.push.PushMessage
 import com.urbanairship.util.UAStringUtil
 
 fun NotificationInfo.canonicalNotificationId() : String {
@@ -47,4 +52,18 @@ fun CustomEvent.Builder.parseProperties(map:HashMap<String, Any>) {
             continue
         }
     }
+}
+
+@RequiresApi(Build.VERSION_CODES.KITKAT)
+fun StatusBarNotification.pushMessage(): PushMessage {
+
+    val extras = this.notification.extras ?: return PushMessage(Bundle())
+
+    val pushBundle = extras.getBundle(PUSH_MESSAGE_BUNDLE_EXTRA)
+    return if (pushBundle == null) {
+        PushMessage(Bundle())
+    } else {
+        PushMessage(pushBundle)
+    }
+
 }

--- a/android/src/main/kotlin/com/airship/flutter/FlutterAutopilot.kt
+++ b/android/src/main/kotlin/com/airship/flutter/FlutterAutopilot.kt
@@ -1,14 +1,19 @@
 package com.airship.flutter
 
 import android.util.Log
+import android.content.Context
 import androidx.annotation.NonNull
+import androidx.core.app.NotificationCompat
+import com.airship.flutter.events.*
 import com.urbanairship.Autopilot
 import com.urbanairship.UAirship
-import com.airship.flutter.events.*
 import com.urbanairship.actions.*
 import com.urbanairship.messagecenter.MessageCenter
 import com.urbanairship.push.*
+import com.urbanairship.push.notifications.AirshipNotificationProvider
+import com.urbanairship.push.notifications.NotificationArguments
 
+const val PUSH_MESSAGE_BUNDLE_EXTRA = "com.urbanairship.push_bundle"
 
 class FlutterAutopilot : Autopilot() {
     override fun onAirshipReady(airship: UAirship) {
@@ -19,6 +24,13 @@ class FlutterAutopilot : Autopilot() {
         // Register a listener for inbox update event
         airship.inbox.addListener {
             EventManager.shared.notifyEvent(InboxUpdatedEvent())
+        }
+
+        airship.pushManager.notificationProvider = object : AirshipNotificationProvider(UAirship.getApplicationContext(), airship.airshipConfigOptions) {
+            override fun onExtendBuilder(context: Context, builder: NotificationCompat.Builder, arguments: NotificationArguments): NotificationCompat.Builder {
+                builder.extras.putBundle(PUSH_MESSAGE_BUNDLE_EXTRA, arguments.message.pushBundle)
+                return super.onExtendBuilder(context, builder, arguments)
+            }
         }
 
         airship.pushManager.addPushListener{ message, notificationPosted ->

--- a/android/src/main/kotlin/com/airship/flutter/Utils.kt
+++ b/android/src/main/kotlin/com/airship/flutter/Utils.kt
@@ -1,9 +1,5 @@
 package com.airship.flutter
 
-import android.os.Build
-import android.os.Bundle
-import android.service.notification.StatusBarNotification
-import androidx.annotation.RequiresApi
 import com.urbanairship.util.UAStringUtil
 import com.urbanairship.push.PushMessage
 import org.json.JSONException
@@ -14,21 +10,9 @@ class Utils {
         val shared = Utils()
     }
 
-    @RequiresApi(Build.VERSION_CODES.KITKAT)
-    fun messageFromNotification(statusBarNotification: StatusBarNotification): PushMessage {
-        val extras = statusBarNotification.notification.extras ?: return PushMessage(Bundle())
-
-        val pushBundle = extras.getBundle(PUSH_MESSAGE_BUNDLE_EXTRA)
-        return if (pushBundle == null) {
-            PushMessage(Bundle())
-        } else {
-            PushMessage(pushBundle)
-        }
-    }
-
     @Throws(JSONException::class)
-    fun notificationObject(message: PushMessage, notificationTag: String, notificationId: String?): Map<String, Any> {
-        val notification = mutableMapOf<String, Any>()
+    fun notificationObject(message: PushMessage, notificationTag: String, notificationId: String?): Map<String, Any?> {
+        val notification = mutableMapOf<String, Any?>()
         val extras = mutableMapOf<String, String>()
         for (key in message.pushBundle.keySet()) {
             if ("android.support.content.wakelockid" == key) {
@@ -49,13 +33,13 @@ class Utils {
         }
 
         if (message.alert != null) {
-            notification["alert"] = message.alert!!
+            notification["alert"] = message.alert
         }
         if (message.title != null) {
-            notification["title"] = message.title!!
+            notification["title"] = message.title
         }
         if (message.summary != null) {
-            notification["subtitle"] = message.summary!!
+            notification["subtitle"] = message.summary
         }
         notification["extras"] = extras;
 

--- a/android/src/main/kotlin/com/airship/flutter/Utils.kt
+++ b/android/src/main/kotlin/com/airship/flutter/Utils.kt
@@ -1,0 +1,76 @@
+package com.airship.flutter
+
+import android.os.Build
+import android.os.Bundle
+import android.service.notification.StatusBarNotification
+import androidx.annotation.RequiresApi
+import com.urbanairship.util.UAStringUtil
+import com.urbanairship.push.PushMessage
+import org.json.JSONException
+
+class Utils {
+
+    companion object {
+        val shared = Utils()
+    }
+
+    @RequiresApi(Build.VERSION_CODES.KITKAT)
+    fun messageFromNotification(statusBarNotification: StatusBarNotification): PushMessage {
+        val extras = statusBarNotification.notification.extras ?: return PushMessage(Bundle())
+
+        val pushBundle = extras.getBundle(PUSH_MESSAGE_BUNDLE_EXTRA)
+        return if (pushBundle == null) {
+            PushMessage(Bundle())
+        } else {
+            PushMessage(pushBundle)
+        }
+    }
+
+    @Throws(JSONException::class)
+    fun notificationObject(message: PushMessage, notificationTag: String, notificationId: String?): Map<String, Any> {
+        val notification = mutableMapOf<String, Any>()
+        val extras = mutableMapOf<String, String>()
+        for (key in message.pushBundle.keySet()) {
+            if ("android.support.content.wakelockid" == key) {
+                continue
+            }
+            if ("google.sent_time" == key) {
+                extras[key] = java.lang.Long.toString(message.pushBundle.getLong(key))
+                continue
+            }
+            if ("google.ttl" == key) {
+                extras[key] = Integer.toString(message.pushBundle.getInt(key))
+                continue
+            }
+            val value = message.pushBundle.getString(key)
+            if (value != null) {
+                extras[key] = value
+            }
+        }
+
+        if (message.alert != null) {
+            notification["message"] = message.alert!!
+        }
+        if (message.title != null) {
+            notification["title"] = message.title!!
+        }
+        if (message.summary != null) {
+            notification["subtitle"] = message.summary!!
+        }
+        notification["extras"] = extras;
+
+        if (notificationId != null) {
+            notification["notification_id"] = notificationId
+            notification["notificationId"] = getNotificationId(notificationId, notificationTag)
+        }
+        return notification
+    }
+
+    private fun getNotificationId(notificationId: String, notificationTag: String): String {
+        var id = notificationId
+        if (!UAStringUtil.isEmpty(notificationTag)) {
+            id += ":$notificationTag"
+        }
+        return id
+    }
+}

--- a/android/src/main/kotlin/com/airship/flutter/Utils.kt
+++ b/android/src/main/kotlin/com/airship/flutter/Utils.kt
@@ -49,7 +49,7 @@ class Utils {
         }
 
         if (message.alert != null) {
-            notification["message"] = message.alert!!
+            notification["alert"] = message.alert!!
         }
         if (message.title != null) {
             notification["title"] = message.title!!

--- a/ios/Classes/SwiftAirshipPlugin.swift
+++ b/ios/Classes/SwiftAirshipPlugin.swift
@@ -92,6 +92,12 @@ UADeepLinkDelegate, UAPushNotificationDelegate, UAInboxDelegate {
             setUserNotificationsEnabled(call, result: result)
         case "getUserNotificationsEnabled":
             getUserNotificationsEnabled(call, result: result)
+        case "clearNotification":
+            clearNotification(call, result: result)
+        case "clearNotifications":
+            clearNotifications(call, result: result)
+        case "getActiveNotifications":
+            getActiveNotifications(call, result: result)
         case "addTags":
             addTags(call, result: result)
         case "addEvent":
@@ -136,6 +142,33 @@ UADeepLinkDelegate, UAPushNotificationDelegate, UAInboxDelegate {
 
     private func getUserNotificationsEnabled(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         result(UAirship.push()?.userPushNotificationsEnabled)
+    }
+    
+    private func getActiveNotifications(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        UNUserNotificationCenter.current().getDeliveredNotifications { (notifications) in
+            
+            let airshipNotifications = NSMutableArray()
+            
+            for notification in notifications {
+                let content = UANotificationContent.notification(with:notification)
+                let pushBody = PushHelpers.pushBodyForNotificationContent(content: content)
+                airshipNotifications.add(pushBody)
+            }
+            
+            result(airshipNotifications)
+        }
+        
+    }
+    
+    private func clearNotification(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let identifier = call.arguments as! String
+        UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers:[identifier])
+        result(nil)
+    }
+    
+    private func clearNotifications(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        UNUserNotificationCenter.current().removeAllDeliveredNotifications()
+        result(nil)
     }
 
     private func addEvent(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
@@ -272,5 +305,31 @@ private extension UACustomEvent {
                 continue
             }
         }
+    }
+}
+
+class PushHelpers{
+    static func pushBodyForNotificationContent(content:UANotificationContent) -> NSMutableDictionary {
+        let pushBody : NSMutableDictionary = NSMutableDictionary()
+        pushBody.setValue(content.alertBody, forKey:"alert")
+        pushBody.setValue(content.alertTitle, forKey:"title")
+        
+        var extras = content.notificationInfo as Dictionary
+        let keys = Array(extras.keys)
+        
+        if keys.contains("aps") {
+            extras.removeValue(forKey:"aps")
+        }
+        if keys.contains("_") {
+            extras.removeValue(forKey:"_")
+        }
+        if extras.count != 0 {
+            pushBody.setValue(extras, forKey:"extras")
+        }
+        
+        let identifier = content.notification?.request.identifier
+        pushBody.setValue(identifier, forKey:"notification_id")
+        
+        return pushBody
     }
 }

--- a/lib/src/airship.dart
+++ b/lib/src/airship.dart
@@ -37,24 +37,26 @@ class Notification {
   final String notificationId;
   final String alert;
   final String title;
+  final String subtitle;
   final Map<String, dynamic> extras;
 
-  const Notification._internal(this.notificationId, this.alert, this.title, this.extras);
+  const Notification._internal(this.notificationId, this.alert, this.title, this.subtitle, this.extras);
 
   static Notification _fromJson(Map<String, dynamic> json) {
     var notificationId = json["notification_id"];
     var alert = json["alert"];
     var title = json["title"];
+    var subtitle = json["subtitle"];
     var extras;
     if (json["extras"] != null) {
       extras = Map<String, dynamic>.from(json["extras"]);
     }
-    return Notification._internal(notificationId, alert, title, extras);
+    return Notification._internal(notificationId, alert, title, subtitle, extras);
   }
 
   @override
   String toString() {
-    return "Notification(notificationId=$notificationId, alert=$alert, title=$title, extras=$extras)";
+    return "Notification(notificationId=$notificationId, alert=$alert, title=$title, subtitle=$subtitle, extras=$extras)";
   }
 }
 

--- a/lib/src/airship.dart
+++ b/lib/src/airship.dart
@@ -45,7 +45,10 @@ class Notification {
     var notificationId = json["notification_id"];
     var alert = json["alert"];
     var title = json["title"];
-    var extras = json["extras"];
+    var extras;
+    if (json["extras"] != null) {
+      extras = Map<String, dynamic>.from(json["extras"]);
+    }
     return Notification._internal(notificationId, alert, title, extras);
   }
 
@@ -148,6 +151,18 @@ class Airship {
     return await _channel.invokeMethod('setUserNotificationsEnabled', enabled);
   }
 
+  static Future<void> clearNotification(String notification) async {
+    if (notification == null) {
+      throw ArgumentError.notNull('notification');
+    }
+
+    return await _channel.invokeMethod('clearNotification', notification);
+  }
+
+  static Future<void> clearNotifications() async {
+    return await _channel.invokeMethod('clearNotifications');
+  }
+
   static Future<List<String>> get tags async {
     List tags = await _channel.invokeMethod("getTags");
     return tags.cast<String>();
@@ -205,6 +220,13 @@ class Airship {
 
   static Future<bool> get userNotificationsEnabled async {
     return await _channel.invokeMethod('getUserNotificationsEnabled');
+  }
+
+  static Future<List<Notification>> get activeNotifications async {
+    List notifications =  await _channel.invokeMethod('getActiveNotifications');
+    return notifications.map((dynamic payload) {
+      return Notification._fromJson(Map<String, dynamic>.from(payload));
+    }).toList();
   }
 
   static Stream<void> get onInboxUpdated {


### PR DESCRIPTION
<!--

Please fill out this template when submitting an pull request.

All lines beginning with an ℹ symbol indicate information that's
important for you to provide to ensure your pull request is reviewed
as quickly and efficiently as possible.

-->


### What do these changes do?
Adds notification management API to flutter implementation 

### Why are these changes necessary?
Allow developers to manage active notifications 

### How did you verify these changes?
Added method calls to airship_bloc.dart 
`Airship.activeNotifications.then((val) {
      debugPrint('Active notifications: $val');
    });` 
then sent a push notification and used the debugger on iOS and Android to check if the API works as expected

#### Verification Screenshots:
<!-- ℹ If applicable, please provide screenshots here. -->

### Anything else a reviewer should know?
I was trying to port the React Native implementation but am not too sure about the activeNotifications Android implementation and what the payload should contain
