### PR TITLE
[MOBILE-594] Notification button support

### DIFF
--- a/android/src/main/kotlin/com/airship/flutter/FlutterAutopilot.kt
+++ b/android/src/main/kotlin/com/airship/flutter/FlutterAutopilot.kt
@@ -12,6 +12,7 @@ import com.urbanairship.messagecenter.MessageCenter
 import com.urbanairship.push.*
 import com.urbanairship.push.notifications.AirshipNotificationProvider
 import com.urbanairship.push.notifications.NotificationArguments
+import androidx.annotation.XmlRes
 
 const val PUSH_MESSAGE_BUNDLE_EXTRA = "com.urbanairship.push_bundle"
 
@@ -91,6 +92,26 @@ class FlutterAutopilot : Autopilot() {
             true
         }
 
+        loadCustomNotificationChannels(UAirship.getApplicationContext(), airship)
+        loadCustomNotificationButtonGroups(UAirship.getApplicationContext(), airship)
+    }
+
+    private fun loadCustomNotificationChannels(context: Context, airship: UAirship) {
+        val packageName = UAirship.getPackageName()
+        @XmlRes val resId = context.resources.getIdentifier("ua_custom_notification_channels", "xml", packageName)
+
+        if (resId != 0) {
+            airship.pushManager.notificationChannelRegistry.createNotificationChannels(resId)
+        }
+    }
+
+    private fun loadCustomNotificationButtonGroups(context: Context, airship: UAirship) {
+        val packageName = UAirship.getPackageName()
+        @XmlRes val resId = context.resources.getIdentifier("ua_custom_notification_buttons", "xml", packageName)
+
+        if (resId != 0) {
+            airship.pushManager.addNotificationActionButtonGroups(context, resId)
+        }
     }
 
     private fun post(event: Event) = EventManager.shared.notifyEvent(event)

--- a/ios/Classes/SwiftAirshipPlugin.swift
+++ b/ios/Classes/SwiftAirshipPlugin.swift
@@ -37,6 +37,8 @@ UADeepLinkDelegate, UAPushNotificationDelegate, UAInboxDelegate {
                                                selector: #selector(inboxUpdated),
                                                name: NSNotification.Name.UAInboxMessageListUpdated,
                                                object: nil)
+        
+        self.loadCustomNotificationCategories()
     }
 
     public func registrationSucceeded(forChannelID channelID: String, deviceToken: String) {
@@ -278,6 +280,16 @@ UADeepLinkDelegate, UAPushNotificationDelegate, UAInboxDelegate {
         let message = UAirship.inbox().messageList.message(forID: call.arguments as! String)
         UAirship.inbox().messageList.markMessagesDeleted([message as Any]) {
             result(nil)
+        }
+    }
+    
+    private func loadCustomNotificationCategories() {
+        guard let categoriesPath = Bundle.main.path(forResource: "UACustomNotificationCategories", ofType: "plist") else { return }
+        let customNotificationCategories = UANotificationCategories.createCategories(fromFile: categoriesPath) as! Set<UANotificationCategory>
+    
+        if customNotificationCategories.count != 0 {
+            UAirship.push()?.customCategories = customNotificationCategories
+            UAirship.push()?.updateRegistration()
         }
     }
 }


### PR DESCRIPTION
### What do these changes do?
Add custom notification button support

### Why are these changes necessary?
To allow for automatic loading of custom notification button categories

### How did you verify these changes?
Created the UACustomNotificationCategories plist/xml file containing custom categories.
Tested manually on both iOS and Android.
