### PR TITLE
[MOBILE-945] fix Android launching OOTB Message Center in sample

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,6 +6,8 @@ import 'package:flutter/services.dart' show DeviceOrientation, SystemChrome;
 import 'package:airship_example/screens/home.dart';
 import 'package:airship_example/screens/settings.dart';
 import 'package:airship_example/screens/message_center.dart';
+import 'package:airship_example/screens/message_view.dart';
+
 import 'package:airship/airship.dart';
 
 // Supported deep links
@@ -30,6 +32,8 @@ class MyApp extends StatefulWidget {
 // SingleTickerProviderStateMixin is used for animation
 class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
   TabController controller;
+
+  final GlobalKey<NavigatorState> key = GlobalKey();
 
   @override
   void initState() {
@@ -91,34 +95,46 @@ class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
   Widget build(BuildContext context) {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
+      navigatorKey:key,
       title: "Airship Sample App",
-      home: Scaffold(
-        body: TabBarView(
-          children: <Widget>[Home(), MessageCenter(), Settings()],
-          controller: controller,
-        ),
-        bottomNavigationBar: Material(
-          // set the color of the bottom navigation bar
-          color: Styles.borders,
-          // set the tab bar as the child of bottom navigation bar
-          child: TabBar(
-            indicatorColor: Styles.airshipRed,
-            tabs: <Tab>[
-              Tab(
-                // set icon to the tab
-                icon: Icon(Icons.home),
-              ),
-              Tab(
-                icon: Icon(Icons.inbox),
-              ),
-              Tab(
-                icon: Icon(Icons.settings),
-              ),
-            ],
-            // setup the controller
-            controller: controller,
+      initialRoute: "/",
+      routes: {
+        '/': (context) => tabBarView(),
+      },
+    );
+  }
+
+  Widget tabBarView() {
+    return WillPopScope( child: Scaffold(
+      body: TabBarView(
+        children: <Widget>[Home(), MessageCenter(), Settings()],
+        controller: controller,
+      ),
+      bottomNavigationBar: bottomNavigationBar(),
+    ));
+  }
+
+  Widget bottomNavigationBar() {
+    return Material(
+      // set the color of the bottom navigation bar
+      color: Styles.borders,
+      // set the tab bar as the child of bottom navigation bar
+      child: TabBar(
+        indicatorColor: Styles.airshipRed,
+        tabs: <Tab>[
+          Tab(
+            // set icon to the tab
+            icon: Icon(Icons.home),
           ),
-        ),
+          Tab(
+            icon: Icon(Icons.inbox),
+          ),
+          Tab(
+            icon: Icon(Icons.settings),
+          ),
+        ],
+        // setup the controller
+        controller: controller,
       ),
     );
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -83,8 +83,21 @@ class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
     Airship.onShowInbox
         .listen((event) => debugPrint('Show inbox'));
 
-    Airship.onShowInboxMessage
-        .listen((messageId) => debugPrint('Show inbox message $messageId'));
+    Airship.onShowInboxMessage.listen((messageId){
+      const message_tab =  1;
+      controller.animateTo(message_tab);
+
+      Airship.inboxMessages.then((List<InboxMessage> messages) {
+        InboxMessage toShow = messages.firstWhere((thisMessage) =>
+        messageId == thisMessage.messageId,
+            orElse: () => null);
+
+        key.currentState.push(MaterialPageRoute<Null>(builder: (BuildContext context) {
+          return MessageView(message: toShow,);
+        }));
+      });
+    });
+
 
     Airship.onChannelRegistration.listen((event) {
       debugPrint('Channel registration $event');

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -89,9 +89,11 @@ class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
         messageId == thisMessage.messageId,
             orElse: () => null);
 
-        key.currentState.push(MaterialPageRoute<Null>(builder: (BuildContext context) {
-          return MessageView(message: toShow,);
-        }));
+        if (toShow != null) {
+          key.currentState.push(MaterialPageRoute<Null>(builder: (BuildContext context) {
+            return MessageView(message: null,);
+          }));
+        }
       });
     });
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -84,9 +84,6 @@ class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
         .listen((event) => debugPrint('Show inbox'));
 
     Airship.onShowInboxMessage.listen((messageId){
-      const message_tab =  1;
-      controller.animateTo(message_tab);
-
       Airship.inboxMessages.then((List<InboxMessage> messages) {
         InboxMessage toShow = messages.firstWhere((thisMessage) =>
         messageId == thisMessage.messageId,
@@ -118,13 +115,15 @@ class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
   }
 
   Widget tabBarView() {
-    return WillPopScope( child: Scaffold(
-      body: TabBarView(
-        children: <Widget>[Home(), MessageCenter(), Settings()],
-        controller: controller,
-      ),
-      bottomNavigationBar: bottomNavigationBar(),
-    ));
+    return WillPopScope(
+        onWillPop: null,
+        child: Scaffold(
+          body: TabBarView(
+            children: <Widget>[Home(), MessageCenter(), Settings()],
+            controller: controller,
+          ),
+          bottomNavigationBar: bottomNavigationBar(),
+        ));
   }
 
   Widget bottomNavigationBar() {

--- a/example/lib/screens/message_center.dart
+++ b/example/lib/screens/message_center.dart
@@ -51,7 +51,7 @@ class _MessageCenterState extends State<MessageCenter> {
               onTap: (){
                 Navigator.push(
                     context,
-                    MaterialPageRoute(builder: (context) => MessageView(message: message, updateParent:updateState,)));
+                    MaterialPageRoute(builder: (context) => MessageView(message: message,)));
               },
             ),
           );

--- a/example/lib/screens/message_view.dart
+++ b/example/lib/screens/message_view.dart
@@ -4,9 +4,8 @@ import 'package:airship_example/styles.dart';
 
 class MessageView extends StatelessWidget {
   final InboxMessage message;
-  final updateParent;
 
-  MessageView({this.message, this.updateParent});
+  MessageView({this.message});
 
   @override
   Widget build(BuildContext context) {
@@ -27,8 +26,6 @@ class MessageView extends StatelessWidget {
         debugPrint("Loading message: ${message.title}");
         controller.loadMessage(message);
         Airship.markInboxMessageRead(message);
-        // Add to message updated sink to indicate message was read
-        updateParent();
       } else {
         debugPrint("Attempted to load message view for null message");
       }


### PR DESCRIPTION
### What do these changes do?
These changes allow onShowInboxMessage events to be correctly handled and display a custom message view instead of the OOTB message view.

### Why are these changes necessary?
To prevent the UI from transitioning to the OOTB message view and inbox when opening a message center message from a push.

### How did you verify these changes?
Manually tested

#### Verification Screenshots:
https://urbanairship.slack.com/archives/G0B2N1MGX/p1572277892077200