### PR TITLE
[MOBILE-946] prep flutter plugin for initial publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 0.0.1
-
-* TODO: Describe initial release.
+Version 1.0.0 - November 1, 2019
+================================
+- Initial release

--- a/README.md
+++ b/README.md
@@ -1,29 +1,26 @@
 # Airship Plugin
 
-Preview of the Airship Flutter plugin.
-
-This plugin is currently in development or published. APIs will most likely change before the first
-major release.
-
-## Status
-
-Feature Status:
-- [x] Tags
-- [x] Notifications
-- [x] Deep links
-- [x] Inbox
-- [x] Named User
-- [x] Push Events
-- [ ] Custom events
-- [ ] Notification management
-- [ ] Tag Groups
+Airship Flutter plugin allows using Airship's native iOS and Android APIs with Flutter apps written in Dart.
 
 ## Usage
 
-This plugin is not yet published, so you will have to use the current master repo as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/).
+1. Add the airship dependency to your package's pubspec.yaml file:
+
 ```
-  airship:
-    git: git://github.com/urbanairship/airship-flutter.git
+dependencies:
+  airship: ^1.0.0
+```
+
+2. Install your flutter package dependencies by running the following in the command line at your project's root directory:
+
+```
+$ flutter pub get
+```
+
+3. Import airship into your project:
+
+```
+import 'package:airship/airship.dart';
 ```
 
 ### Android Setup

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Airship Plugin
 
-Airship Flutter plugin allows using Airship's native iOS and Android APIs with Flutter apps written in Dart.
+The Airship Flutter plugin allows using Airship's native iOS and Android APIs with Flutter apps written in Dart.
 
 ## Usage
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: airship
 description: Airship flutter plugin.
 version: 1.0.0
-author: Airship
+author: Airship <support@airship.com>
 homepage: https://www.airship.com/
 
 environment:


### PR DESCRIPTION
### What do these changes do?
Updates the flutter plugin to prepare for publish.

### Why are these changes necessary?
To push the plugin to pub.dev.

### How did you verify these changes?
Ran publish dry run via
`flutter pub pub publish --dry-run`

#### Verification Screenshots:
![image](https://user-images.githubusercontent.com/2199816/67998228-ed29dd00-fc14-11e9-8cb4-34b6e270ce10.png)