### PR TITLE
MOBILE-1199: Delayed channel creation support

### DIFF
--- a/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
+++ b/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
@@ -25,18 +25,18 @@ import io.flutter.plugin.common.StandardMessageCodec
 import io.flutter.plugin.platform.PlatformView
 import io.flutter.plugin.platform.PlatformViewFactory
 
-private val TAG_OPERATION_GROUP_NAME = "group"
-private val TAG_OPERATION_TYPE = "operationType"
-private val TAG_OPERATION_TAGS = "tags"
-private val TAG_OPERATION_ADD = "add"
-private val TAG_OPERATION_REMOVE = "remove"
-private val TAG_OPERATION_SET = "set"
+private const val TAG_OPERATION_GROUP_NAME = "group"
+private const val TAG_OPERATION_TYPE = "operationType"
+private const val TAG_OPERATION_TAGS = "tags"
+private const val TAG_OPERATION_ADD = "add"
+private const val TAG_OPERATION_REMOVE = "remove"
+private const val TAG_OPERATION_SET = "set"
 
-private val ATTRIBUTE_MUTATION_TYPE = "action"
-private val ATTRIBUTE_MUTATION_KEY = "key"
-private val ATTRIBUTE_MUTATION_VALUE = "value"
-private val ATTRIBUTE_MUTATION_REMOVE = "remove"
-private val ATTRIBUTE_MUTATION_SET = "set"
+private const val ATTRIBUTE_MUTATION_TYPE = "action"
+private const val ATTRIBUTE_MUTATION_KEY = "key"
+private const val ATTRIBUTE_MUTATION_VALUE = "value"
+private const val ATTRIBUTE_MUTATION_REMOVE = "remove"
+private const val ATTRIBUTE_MUTATION_SET = "set"
 
 class InboxMessageViewFactory(private val registrar: Registrar) : PlatformViewFactory(StandardMessageCodec.INSTANCE) {
     override fun create(context: Context, viewId: Int, arguments: Any?): PlatformView {
@@ -113,7 +113,7 @@ class AirshipPlugin : MethodCallHandler {
             "markInboxMessageRead" -> markInboxMessageRead(call, result)
             "deleteInboxMessage" -> deleteInboxMessage(call, result)
             "setInAppAutomationPaused" -> setInAppAutomationPaused(call, result)
-            "getInAppAutomationPaused" -> getInAppAutomationPaused(call, result)
+            "getInAppAutomationPaused" -> getInAppAutomationPaused(result)
             else -> result.notImplemented()
         }
     }
@@ -199,51 +199,47 @@ class AirshipPlugin : MethodCallHandler {
 
     private fun removeTags(call: MethodCall, result: Result) {
         val tags = uncheckedCast<List<String>>(call.arguments).toSet()
-        UAirship.shared().pushManager.editTags().removeTags(tags).apply()
+        UAirship.shared().channel.editTags().removeTags(tags).apply()
         result.success(null)
     }
 
     private fun getTags(result: Result) {
-        result.success(ArrayList<String>(UAirship.shared().pushManager.tags))
+        result.success(ArrayList<String>(UAirship.shared().channel.tags))
     }
 
     private fun editChannelTagGroups(call: MethodCall, result: Result) {
         var operations = call.arguments as ArrayList<Map<String, Any?>>
-        this.applyTagGroupOperations(UAirship.shared().getPushManager().editTagGroups(), operations)
+        this.applyTagGroupOperations(UAirship.shared().channel.editTagGroups(), operations)
         result.success(null)
     }
 
     private fun editNamedUserTagGroups(call: MethodCall, result: Result) {
         var operations = call.arguments as ArrayList<Map<String, Any?>>
-        this.applyTagGroupOperations(UAirship.shared().getNamedUser().editTagGroups(), operations)
+        this.applyTagGroupOperations(UAirship.shared().namedUser.editTagGroups(), operations)
         result.success(null)
     }
 
     private fun applyTagGroupOperations(editor: TagGroupsEditor, operations: ArrayList<Map<String, Any?>>) {
         for (i in 0 until operations.size) {
-            var operation = operations.get(i)
-            if (operation == null) {
-                continue;
-            }
+            val operation: Map<String, Any?> = operations[i]
+            val group = operation[TAG_OPERATION_GROUP_NAME] as String
+            val tags = operation[TAG_OPERATION_TAGS] as ArrayList<String?>
+            val operationType = operation[TAG_OPERATION_TYPE] as String
 
-            var group = operation[TAG_OPERATION_GROUP_NAME] as String ?: continue
-            var tags = operation[TAG_OPERATION_TAGS] as ArrayList<String?> ?: continue
-            var operationType = operation[TAG_OPERATION_TYPE] as String ?: continue
-
-            var tagSet = mutableSetOf<String?>()
+            val tagSet = mutableSetOf<String?>()
             for (j in 0 until tags.size) {
-                var tag = tags[j] as String?
+                val tag = tags[j]
                 if (tag != null) {
                     tagSet.add(tag)
                 }
             }
 
-            if (TAG_OPERATION_ADD.equals(operationType)) {
-                editor.addTags(group, tagSet);
-            } else if (TAG_OPERATION_REMOVE.equals(operationType)) {
-                editor.removeTags(group, tagSet);
-            } else if (TAG_OPERATION_SET.equals(operationType)) {
-                editor.setTags(group, tagSet);
+            if (TAG_OPERATION_ADD == operationType) {
+                editor.addTags(group, tagSet)
+            } else if (TAG_OPERATION_REMOVE == operationType) {
+                editor.removeTags(group, tagSet)
+            } else if (TAG_OPERATION_SET == operationType) {
+                editor.setTags(group, tagSet)
             }
         }
 
@@ -315,33 +311,33 @@ class AirshipPlugin : MethodCallHandler {
 
         if (UAStringUtil.isEmpty(identifier)) {
             result.error("InvalidIdentifierFormat", "Unable to clear notification", null)
-            return;
+            return
         }
 
         val parts = identifier.split(":", ignoreCase = true, limit = 2)
-        if (parts.size == 0) {
+        if (parts.isEmpty()) {
             result.error("InvalidIdentifierFormat", "Unable to clear notification", null)
-            return;
+            return
         }
 
         var tag = String()
-        var id = 0
+        var id: Int
 
         try {
-            id = (parts[0]).toInt();
+            id = (parts[0]).toInt()
         } catch (e: NumberFormatException) {
             result.error("InvalidIdentifierFormat", "Unable to clear notification", null)
-            return;
+            return
         }
 
         if (parts.size == 2) {
-            tag = parts[1];
+            tag = parts[1]
         }
 
         if (tag == "") {
-            NotificationManagerCompat.from(UAirship.getApplicationContext()).cancel(null, id);
+            NotificationManagerCompat.from(UAirship.getApplicationContext()).cancel(null, id)
         } else {
-            NotificationManagerCompat.from(UAirship.getApplicationContext()).cancel(tag, id);
+            NotificationManagerCompat.from(UAirship.getApplicationContext()).cancel(tag, id)
         }
 
         result.success(true)
@@ -359,12 +355,12 @@ class AirshipPlugin : MethodCallHandler {
         result.success(true)
     }
 
-    private fun getInAppAutomationPaused(call: MethodCall, result: Result) {
+    private fun getInAppAutomationPaused(result: Result) {
         result.success(UAirship.shared().inAppMessagingManager.isPaused)
     }
 
     fun getChannelId(result: Result) {
-        result.success(UAirship.shared().pushManager.channelId)
+        result.success(UAirship.shared().channel.id)
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
+++ b/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
@@ -114,6 +114,7 @@ class AirshipPlugin : MethodCallHandler {
             "deleteInboxMessage" -> deleteInboxMessage(call, result)
             "setInAppAutomationPaused" -> setInAppAutomationPaused(call, result)
             "getInAppAutomationPaused" -> getInAppAutomationPaused(result)
+            "enableChannelCreation" -> enableChannelCreation(result)
             else -> result.notImplemented()
         }
     }
@@ -361,6 +362,12 @@ class AirshipPlugin : MethodCallHandler {
 
     fun getChannelId(result: Result) {
         result.success(UAirship.shared().channel.id)
+    }
+
+
+    private fun enableChannelCreation(result: Result) {
+        UAirship.shared().channel.enableChannelCreation()
+        result.success(null)
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/android/src/main/kotlin/com/airship/flutter/FlutterAutopilot.kt
+++ b/android/src/main/kotlin/com/airship/flutter/FlutterAutopilot.kt
@@ -13,6 +13,7 @@ import com.urbanairship.push.*
 import com.urbanairship.push.notifications.AirshipNotificationProvider
 import com.urbanairship.push.notifications.NotificationArguments
 import androidx.annotation.XmlRes
+import com.urbanairship.channel.AirshipChannelListener
 
 const val PUSH_MESSAGE_BUNDLE_EXTRA = "com.urbanairship.push_bundle"
 
@@ -62,17 +63,14 @@ class FlutterAutopilot : Autopilot() {
             override fun onNotificationDismissed(@NonNull notificationInfo: NotificationInfo) {}
         })
 
-        airship.pushManager.addRegistrationListener(object : RegistrationListener {
+        airship.channel.addChannelListener(object : AirshipChannelListener {
             override fun onChannelCreated(channelId: String) {
-
-                post(ChannelRegistrationEvent(channelId, UAirship.shared().pushManager.registrationToken))
+                post(ChannelRegistrationEvent(channelId, UAirship.shared().pushManager.pushToken))
             }
 
             override fun onChannelUpdated(channelId: String) {
-                post(ChannelRegistrationEvent(channelId, UAirship.shared().pushManager.registrationToken))
+                post(ChannelRegistrationEvent(channelId, UAirship.shared().pushManager.pushToken))
             }
-
-            override fun onPushTokenUpdated(pushToken: String) {}
         })
 
         airship.messageCenter.setOnShowMessageCenterListener(object : MessageCenter.OnShowMessageCenterListener {

--- a/ios/Classes/SwiftAirshipPlugin.swift
+++ b/ios/Classes/SwiftAirshipPlugin.swift
@@ -132,6 +132,8 @@ UADeepLinkDelegate, UAPushNotificationDelegate, UAInboxDelegate {
             setInAppAutomationPaused(call, result: result)
         case "getInAppAutomationPaused":
             getInAppAutomationPaused(call, result: result)
+        case "enableChannelCreation":
+            enableChannelCreation(call, result: result)
         default:
             result(FlutterError(code:"UNAVAILABLE",
                 message:"Unknown method: \(call.method)",
@@ -357,6 +359,11 @@ UADeepLinkDelegate, UAPushNotificationDelegate, UAInboxDelegate {
 
     private func getInAppAutomationPaused(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         result(UAirship.inAppMessageManager()?.isPaused)
+    }
+
+    private func enableChannelCreation(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        UAirship.channel()?.enableCreation()
+        result(nil)
     }
 }
 

--- a/lib/src/airship.dart
+++ b/lib/src/airship.dart
@@ -244,6 +244,10 @@ class Airship {
     }).toList();
   }
 
+  static Future<void> enableChannelCreation() async {
+    return await _channel.invokeMethod('enableChannelCreation');
+  }
+
   static Stream<void> get onInboxUpdated {
     return _getEventStream("INBOX_UPDATED");
   }


### PR DESCRIPTION
### What do these changes do?
In order for the delay channel creation feature to work, we need to expose the enable channel creation call in flutter. This adds it.

### Why are these changes necessary?
Customer request.

### How did you verify these changes?
Manually verified the enableChannelCreation call is able to be triggered.
