### PR TITLE
[MOBILE-1272] add data collection enabled flag to flutter

### DIFF
--- a/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
+++ b/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
@@ -116,8 +116,10 @@ class AirshipPlugin : MethodCallHandler {
             "getInAppAutomationPaused" -> getInAppAutomationPaused(result)
             "enableChannelCreation" -> enableChannelCreation(result)
             "trackScreen" -> trackScreen(call, result)
-            "setPushTokenRegistrationEnabled" -> setPushTokenRegistrationEnabled(call, result)
+            "getDataCollectionEnabled" -> getDataCollectionEnabled(result)
+            "getPushTokenRegistrationEnabled" -> getPushTokenRegistrationEnabled(result)
             "setDataCollectionEnabled" -> setDataCollectionEnabled(call, result)
+            "setPushTokenRegistrationEnabled" -> setPushTokenRegistrationEnabled(call, result)
 
             else -> result.notImplemented()
         }
@@ -306,8 +308,16 @@ class AirshipPlugin : MethodCallHandler {
         result.success(true)
     }
 
+    private fun getDataCollectionEnabled(result: Result) {
+        result.success(UAirship.shared().isDataCollectionEnabled)
+    }
+
+    private fun getPushTokenRegistrationEnabled(result: Result) {
+        result.success(UAirship.shared().pushManager.isPushTokenRegistrationEnabled)
+    }
+
     private fun setDataCollectionEnabled(call: MethodCall, result: Result) {
-        UAirship.shared().isDataCollectionEnabled = call.arguments as Boolean
+        UAirship.shared().isDataCollectionEnabled = (call.arguments as Boolean)
         result.success(true)
     }
 

--- a/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
+++ b/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
@@ -116,6 +116,9 @@ class AirshipPlugin : MethodCallHandler {
             "getInAppAutomationPaused" -> getInAppAutomationPaused(result)
             "enableChannelCreation" -> enableChannelCreation(result)
             "trackScreen" -> trackScreen(call, result)
+            "setPushTokenRegistrationEnabled" -> setPushTokenRegistrationEnabled(call, result)
+            "setDataCollectionEnabled" -> setDataCollectionEnabled(call, result)
+
             else -> result.notImplemented()
         }
     }
@@ -300,6 +303,16 @@ class AirshipPlugin : MethodCallHandler {
 
     private fun setUserNotificationsEnabled(call: MethodCall, result: Result) {
         UAirship.shared().pushManager.userNotificationsEnabled = call.arguments as Boolean
+        result.success(true)
+    }
+
+    private fun setDataCollectionEnabled(call: MethodCall, result: Result) {
+        UAirship.shared().isDataCollectionEnabled = call.arguments as Boolean
+        result.success(true)
+    }
+
+    private fun setPushTokenRegistrationEnabled(call: MethodCall, result: Result) {
+        UAirship.shared().pushManager.pushTokenRegistrationEnabled = (call.arguments as Boolean)
         result.success(true)
     }
 

--- a/ios/Classes/SwiftAirshipPlugin.swift
+++ b/ios/Classes/SwiftAirshipPlugin.swift
@@ -143,6 +143,10 @@ UADeepLinkDelegate, UAPushNotificationDelegate {
             enableChannelCreation(call, result: result)
         case "trackScreen":
             trackScreen(call, result: result)
+        case "setDataCollectionEnabled":
+            setDataCollectionEnabled(call, result: result)
+        case "setPushTokenRegistrationEnabled":
+            setPushTokenRegistrationEnabled(call, result: result)
         default:
             result(FlutterError(code:"UNAVAILABLE",
                 message:"Unknown method: \(call.method)",
@@ -152,6 +156,18 @@ UADeepLinkDelegate, UAPushNotificationDelegate {
 
     private func getChannelId(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         result(UAirship.channel().identifier)
+    }
+
+    private func setDataCollectionEnabled(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let enable = call.arguments as! Bool
+        UAirship.shared().isDataCollectionEnabled = enable
+        result(true)
+    }
+
+    private func setPushTokenRegistrationEnabled(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let enable = call.arguments as! Bool
+        UAPush.shared().pushTokenRegistrationEnabled = enable
+        result(true)
     }
 
     private func setUserNotificationsEnabled(_ call: FlutterMethodCall, result: @escaping FlutterResult) {

--- a/ios/Classes/SwiftAirshipPlugin.swift
+++ b/ios/Classes/SwiftAirshipPlugin.swift
@@ -143,6 +143,10 @@ UADeepLinkDelegate, UAPushNotificationDelegate {
             enableChannelCreation(call, result: result)
         case "trackScreen":
             trackScreen(call, result: result)
+        case "getDataCollectionEnabled":
+            getDataCollectionEnabled(call, result: result)
+        case "getPushTokenRegistrationEnabled":
+            getPushTokenRegistrationEnabled(call, result: result)
         case "setDataCollectionEnabled":
             setDataCollectionEnabled(call, result: result)
         case "setPushTokenRegistrationEnabled":
@@ -156,6 +160,14 @@ UADeepLinkDelegate, UAPushNotificationDelegate {
 
     private func getChannelId(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         result(UAirship.channel().identifier)
+    }
+
+    private func getDataCollectionEnabled(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        result(UAirship.shared().isDataCollectionEnabled)
+    }
+
+    private func getPushTokenRegistrationEnabled(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        result(UAPush.shared().pushTokenRegistrationEnabled)
     }
 
     private func setDataCollectionEnabled(_ call: FlutterMethodCall, result: @escaping FlutterResult) {

--- a/lib/src/airship.dart
+++ b/lib/src/airship.dart
@@ -313,4 +313,20 @@ class Airship {
 
     return await _channel.invokeMethod('trackScreen', screen);
   }
+
+  static Future<bool> setDataCollectionEnabled(bool enabled) async {
+    if (enabled == null) {
+      throw ArgumentError.notNull('enabled');
+    }
+
+    return await _channel.invokeMethod('setDataCollectionEnabled', enabled);
+  }
+
+  static Future<bool> setPushTokenRegistrationEnabled(bool enabled) async {
+    if (enabled == null) {
+      throw ArgumentError.notNull('enabled');
+    }
+
+    return await _channel.invokeMethod('setPushTokenRegistrationEnabled', enabled);
+  }
 }

--- a/lib/src/airship.dart
+++ b/lib/src/airship.dart
@@ -314,6 +314,14 @@ class Airship {
     return await _channel.invokeMethod('trackScreen', screen);
   }
 
+  static Future<bool> get getDataCollectionEnabled async {
+    return await _channel.invokeMethod('getDataCollectionEnabled');
+  }
+
+  static Future<bool> get getPushTokenRegistrationEnabled async {
+    return await _channel.invokeMethod('getPushTokenRegistrationEnabled');
+  }
+
   static Future<bool> setDataCollectionEnabled(bool enabled) async {
     if (enabled == null) {
       throw ArgumentError.notNull('enabled');


### PR DESCRIPTION
### What do these changes do?
Add data collection and push token collection enablement to airship-flutter

### Why are these changes necessary?
To allow customers using the flutter integration to use these features.

### How did you verify these changes?
Manually tested that the switching results in the correct method calls.