### PR TITLE
[MOBILE-1286] Move Flutter deploy to Github Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+  
+name: Release
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+*"
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: "12.x"
+      - uses: subosito/flutter-action@v1
+        with:
+          channel: "stable"
+      - name: Run CI
+        run: bash ./scripts/run_ci_tasks.sh -z
+  android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: "12.x"
+      - uses: subosito/flutter-action@v1
+        with:
+          channel: "stable"
+      - name: Run CI
+        run: bash ./scripts/run_ci_tasks.sh -a
+  ios:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: "12.x"
+      - uses: subosito/flutter-action@v1
+        with:
+          channel: "stable"
+      - name: Run CI
+        run: bash ./scripts/run_ci_tasks.sh -i
+  publish:
+    runs-on: ubuntu-latest
+    needs: [analyze, android, ios]
+    steps:
+      - name: Publish Dart/Flutter package
+        uses: sakebook/actions-flutter-pub-publisher@v1.2.1
+        with:
+          # Google Account credential JSON
+          credential:  ${{ secrets.PUB_DEV_CREDENTIALS }}
+  finished:
+    runs-on: ubuntu-latest
+    needs: [analyze, android, ios, publish]
+    steps:
+      - name: Slack Notification
+        uses: homoluctus/slatify@master
+        if: always()
+        with:
+          type: ${{ job.status }}
+          job_name: ":raised_hands: Airship Flutter Plugin Released! :raised_hands:"
+          url: ${{ secrets.MOBILE_SLACK_WEBHOOK }}


### PR DESCRIPTION
### What do these changes do?
Adds flutter deploy job to github actions.

### Why are these changes necessary?
To allow flutter deploys from github actions.

### How did you verify these changes?
The build/ios/android jobs are all verified and currently in use. Not able to verify publish and finish jobs yet, will have to run them. Verified pub-dev credentials and slack hook.