### PR TITLE
[fix-release-workflow] failed() -> failure()

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Slack Notification
         uses: homoluctus/slatify@master
-        if: failed()
+        if: failure()
         with:
           type: ${{ job.status }}
           job_name: "Failed to release Flutter :("


### PR DESCRIPTION
It looks like we just got the function name wrong here.