### PR TITLE
Adds updateRegistration() support to the Flutter API

### DIFF
--- a/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
+++ b/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
@@ -129,6 +129,7 @@ class AirshipPlugin : MethodCallHandler {
             "clearNotifications" -> clearNotifications(result)
             "getActiveNotifications" -> getActiveNotifications(result)
             "addTags" -> addTags(call, result)
+            "updateRegistration" -> updateRegistration(call, result)
             "addEvent" -> addEvent(call, result)
             "removeTags" -> removeTags(call, result)
             "getTags" -> getTags(result)
@@ -192,6 +193,11 @@ class AirshipPlugin : MethodCallHandler {
     private fun addTags(call: MethodCall, result: Result) {
         val tags = uncheckedCast<List<String>>(call.arguments).toSet()
         UAirship.shared().pushManager.editTags().addTags(tags).apply()
+        result.success(null)
+    }
+
+    private fun updateRegistration(call: MethodCall, result: Result) {
+        UAirship.shared().getChannel().updateRegistration()
         result.success(null)
     }
 

--- a/ios/Classes/SwiftAirshipPlugin.swift
+++ b/ios/Classes/SwiftAirshipPlugin.swift
@@ -113,6 +113,8 @@ UADeepLinkDelegate, UAPushNotificationDelegate {
             getActiveNotifications(call, result: result)
         case "addTags":
             addTags(call, result: result)
+        case "updateRegistration":
+            updateRegistration(call, result: result)
         case "addEvent":
             addEvent(call, result: result)
         case "removeTags":
@@ -272,6 +274,11 @@ UADeepLinkDelegate, UAPushNotificationDelegate {
     private func addTags(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         let tags = call.arguments as! [String]
         UAirship.channel().addTags(tags)
+        UAirship.channel().updateRegistration()
+        result(nil)
+    }
+
+    private func updateRegistration(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         UAirship.channel().updateRegistration()
         result(nil)
     }

--- a/lib/src/airship_flutter.dart
+++ b/lib/src/airship_flutter.dart
@@ -204,7 +204,7 @@ class Airship {
     return await _channel.invokeMethod('addTags', tags);
   }
 
-  static Future<String> get updateRegistration async {
+  static Future<String> updateRegistration() async {
     return await _channel.invokeMethod('updateRegistration');
   }
 

--- a/lib/src/airship_flutter.dart
+++ b/lib/src/airship_flutter.dart
@@ -204,6 +204,10 @@ class Airship {
     return await _channel.invokeMethod('addTags', tags);
   }
 
+  static Future<String> get updateRegistration async {
+    return await _channel.invokeMethod('updateRegistration');
+  }
+
   static Future<void> removeTags(List<String> tags) async {
     if (tags == null) {
       throw ArgumentError.notNull('tags');


### PR DESCRIPTION
Co-authored-by: Jacob Clark <jacob.jh.clark@googlemail.com>
Co-authored-by: Chris Grounds <chrisbacon2009@hotmail.com>

### What do these changes do?
Exposes the updateRegistration API to the Flutter client to enable apps to immediately register their users preferences when toggling notifications on or off.

### Why are these changes necessary?
To enable Flutter developers to choose when their notification permissions are synced to prevent users receiving notifications they have opted out of.

### How did you verify these changes?
Manually integrated the package into a test Flutter app in Android and iOS.

#### Verification Screenshots:
N/A

### Anything else a reviewer should know?
N/A