### PR TITLE
[MOBILE-1545] fix example to properly show state changes

### DIFF
--- a/example/lib/screens/settings.dart
+++ b/example/lib/screens/settings.dart
@@ -36,6 +36,7 @@ class _SettingsState extends State<Settings> {
                       value: snapshot.data ?? false,
                       onChanged: (bool enabled){
                         Airship.setUserNotificationsEnabled(enabled);
+                        updateState();
                       },
                     );}),
                 FutureBuilder(

--- a/example/lib/screens/tag_add.dart
+++ b/example/lib/screens/tag_add.dart
@@ -40,6 +40,7 @@ class _TagAddState extends State<TagAdd> {
                   .showSnackBar(SnackBar(content: Text("tag \"$tag\" removed")));
               tags.remove(tag);
               Airship.removeTags([tag]);
+              updateState();
             },
             child: Card(
                 elevation: 5.0,
@@ -80,7 +81,7 @@ class _TagAddState extends State<TagAdd> {
                       onTap: (tagText){
                         FocusScope.of(context).unfocus();
                         Airship.addTags([tagText]);
-                        updateParent();
+                        updateState();
                       },
                     ),
                   ),
@@ -90,5 +91,10 @@ class _TagAddState extends State<TagAdd> {
             );
           },
         ));
+  }
+
+  updateState() {
+    updateParent();
+    setState(() {});
   }
 }


### PR DESCRIPTION
### What do these changes do?
In testing an issue, saw that some state was failing to update in the example. This fixes this state change issue by calling update state at the appropriate times.

### Why are these changes necessary?
Make the sample properly display state.

### How did you verify these changes?
Manual tests

#### Verification Screenshots:
This gif itself has a low frame rate - the frame rate is fine in the app:
![works](https://user-images.githubusercontent.com/2199816/80779260-fc380c00-8b1f-11ea-8d53-23ba4a83d898.gif)