### PR TITLE
[MOBILE-1535] Update iOS SDK to 13.3.0

### DIFF
--- a/ios/Classes/SwiftAirshipPlugin.swift
+++ b/ios/Classes/SwiftAirshipPlugin.swift
@@ -246,7 +246,7 @@ UADeepLinkDelegate, UAPushNotificationDelegate {
         let customEvent = UACustomEvent(name:name, value:NSNumber(value: value))
 
         if let properties = event[propertiesKey] as? Dictionary<String, Any> {
-            customEvent.parseProperties(properties:properties)
+            customEvent.properties = properties
         }
 
         if let transactionID = event[transactionIDKey] as? String {
@@ -432,32 +432,6 @@ UADeepLinkDelegate, UAPushNotificationDelegate {
         
         UAirship.analytics()?.trackScreen(screen)
         result(nil)
-    }
-}
-
-private extension UACustomEvent {
-    func parseProperties(properties:Dictionary<String, Any>) {
-        for (key, value) in properties {
-            if let numVal = value as? NSNumber, CFGetTypeID(numVal) == CFNumberGetTypeID() {
-                self.setNumberProperty(numVal, forKey: key)
-                continue
-            }
-
-            if let boolValue = value as? Bool, CFGetTypeID(value as? NSNumber) == CFBooleanGetTypeID() {
-                self.setBoolProperty(boolValue, forKey: key)
-                continue
-            }
-
-            if let stringValue = value as? String {
-                self.setStringProperty(stringValue, forKey: key)
-                continue
-            }
-
-            if let stringArray = value as? [String] {
-                self.setStringArrayProperty(stringArray, forKey: key)
-                continue
-            }
-        }
     }
 }
 

--- a/ios/airship_flutter.podspec
+++ b/ios/airship_flutter.podspec
@@ -20,6 +20,6 @@ Airship flutter plugin.
   s.dependency 'Flutter'
 
   s.ios.deployment_target   = "11.0"
-  s.dependency              'Airship', '~> 13.1.0'
+  s.dependency              'Airship', '~> 13.3.0'
 end
 


### PR DESCRIPTION
Updates to latest iOS SDK to fix issue for https://github.com/urbanairship/airship-flutter/pull/47. 

Custom event property methods could be updated to support any JSON on the dart side but we will do that in a separate PR after Android SDK is updated.