### PR TITLE
[MOBILE-1563] - Remove property restrictions for  custom events in flutter

### DIFF
--- a/lib/src/custom_event.dart
+++ b/lib/src/custom_event.dart
@@ -35,7 +35,7 @@ class CustomEvent {
   }
 
   ///
-  /// Sets a custom event properties.
+  /// Sets custom event properties.
   ///
   /// @param properties The custom event properties.
   ///

--- a/lib/src/custom_event.dart
+++ b/lib/src/custom_event.dart
@@ -19,45 +19,31 @@ class CustomEvent {
         this.value = value;
 
   ///
-  /// Sets a custom BOOL property.
+  /// Adds a custom event property.
   ///
   /// @param key The property key.
   /// @param value The property value.
   ///
-  void setBoolProperty(String key, bool value) {
+  void addProperty(String key, dynamic value) {
+    if (key == null) {
+      throw ArgumentError.notNull('key');
+    }
+    if (value == null) {
+      throw ArgumentError.notNull('value');
+    }
     _properties[key] = value;
   }
 
   ///
-  /// Sets a custom String property. The value's length must not exceed 255 characters
-  /// or it will invalidate the event.
+  /// Sets a custom event properties.
   ///
-  /// @param key The property key.
-  /// @param value The property value.
+  /// @param properties The custom event properties.
   ///
-  void setStringProperty(String key, String value) {
-    _properties[key] = value;
-  }
-
-  ///
-  /// Sets a custom Number property.
-  ///
-  /// @param key The property key.
-  /// @param value The property value.
-  ///
-  void setNumberProperty(String key, int value) {
-    _properties[key] = value;
-  }
-
-  ///
-  /// Sets a custom String list property. The list must not exceed 20 entries and
-  /// each entry's length must not exceed 255 characters or it will invalidate the event.
-  ///
-  /// @param key The property key.
-  /// @param value The property value.
-  ///
-  void setStringArrayProperty(String key, List<String> arr) {
-    _properties[key] = arr;
+  void setProperties(Map<String, dynamic> properties) {
+    if (properties == null) {
+      throw ArgumentError.notNull('properties');
+    }
+    properties.forEach((key,value) => _properties[key] = value);
   }
 
   Map<String, dynamic> toMap() {


### PR DESCRIPTION
### What do these changes do?
Update the custom event property to `setProperties(Map<String, dynamic>)` and `addProperty(String, dyamic)`. 

### How did you verify these changes?
Using the example app.
example of code: 
```
    CustomEvent event = CustomEvent("Event name", 123);
    event.addProperty("test", true);
    event.addProperty("First name", true);
    event.addProperty("Last name", "lastname");
```

```
    var properties = new Map<String, dynamic>();
    properties["First name"] = "Me";
    properties["age"] = 30;
    event.setProperties(properties);
    Airship.addEvent(event);
```