### PR TITLE
[MOBILE-1770] Update Flutter to iOS SDK Version 13.5.2

### DIFF
--- a/ios/airship_flutter.podspec
+++ b/ios/airship_flutter.podspec
@@ -20,6 +20,6 @@ Airship flutter plugin.
   s.dependency 'Flutter'
 
   s.ios.deployment_target   = "11.0"
-  s.dependency              'Airship', '~> 13.3.0'
+  s.dependency              'Airship', '~> 13.5.2'
 end
 


### PR DESCRIPTION
### What do these changes do?
Updating the Flutter iOS SDK used to version 13.5.2

### Why are these changes necessary?
To stay updated

### How did you verify these changes?
Launching the app, testing basic functionalities of Airship, and checking that the correct version is loaded.