### PR TITLE
Fix exception in example app.

### DIFF
--- a/DEV_README.md
+++ b/DEV_README.md
@@ -8,7 +8,7 @@
 
 2. Make sure flutter is in the tool chain
 
-3. Make sure flutter doctor to make sure everything is setup
+3. Run `flutter doctor` to make sure everything is setup
 
 ### Plugin Development
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,6 +16,7 @@ const String message_center_deep_link =  "message_center";
 const String settings_deep_link =  "settings";
 
 void main() {
+  WidgetsFlutterBinding.ensureInitialized();
   SystemChrome.setPreferredOrientations([
     DeviceOrientation.portraitUp,
     DeviceOrientation.portraitDown,


### PR DESCRIPTION
### What do these changes do?
Fix exception in the example app.

### Why are these changes necessary?
Example app needs to work.

### How did you verify these changes?
Launched app successfully.

### Anything else a reviewer should know?
Example app was throwing the following exception on launch: 
```
ServicesBinding.defaultBinaryMessenger was accessed before the binding was initialized.
If you’re running an application and need to access the binary messenger before `runApp()` has been called (for example, during plugin initialization), then you need to explicitly call the `WidgetsFlutterBinding.ensureInitialized()` first.
```
Simply following the instructions fixed the problem.
