### PR TITLE
fix intl version for issue #64

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  intl: ^0.15.7
+  intl: ">=0.15.7 <0.18.0"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
https://github.com/urbanairship/airship-flutter/issues/64

<!--

Please fill out this template when submitting a pull request.

All lines beginning with an ℹ symbol indicate information that's
important for you to provide to ensure your pull request is reviewed
as quickly and efficiently as possible.

-->

### What do these changes do?
ℹ  Fix the intl version to make it useable for the latest Flutter stable channel

### Why are these changes necessary?
ℹ  Can't use the latest flutter stable or an airship version below 3.1.0 because of XCode 12

### How did you verify these changes?
ℹ  Please use an application with intl package and the Xcode version 12 to test this fixes.

#### Verification Screenshots:
ℹ  --

### Anything else a reviewer should know?
ℹ  --
