### PR TITLE
[MOBILE-2139] Update iOS SDK version in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Flutter Plugin Changelog
 
 ## Version 4.2.0 - April 06, 2021
-Minor release updating the iOS and Android SDKs to 14.3.1 ans 14.3.0.
+Minor release updating the iOS and Android SDKs to 14.3.1 and 14.3.0.
 
 ### Changes
 - Updated iOS SDK to 14.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Flutter Plugin Changelog
 
 ## Version 4.2.0 - April 06, 2021
-Minor release updating the iOS and Android SDKs to 14.3.0. 
+Minor release updating the iOS and Android SDKs to 14.3.1 ans 14.3.0.
 
 ### Changes
-- Updated iOS SDK to 14.3.0
+- Updated iOS SDK to 14.3.1
 - Updated Android SDK to 14.3.0
 - Added extras to the message center payload
 

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -46,7 +46,7 @@ if $UPLOAD; then
         exit 1
     fi
 
-    ROOT_PATH='dirname "${0}"'/..
+    ROOT_PATH=$(dirname "${0}")/..
     TAR_NAME="$1.tar.gz"
 
     cd "$2"


### PR DESCRIPTION
I updated the iOS SDK version with our last version but I noticed I forgot to update it in the changelog.

I also fixed my mess in the docs script