### PR TITLE
Add repository and issue tracker to the pubspec

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,8 @@ name: airship_flutter
 description: "The Airship flutter plugin. This package implements a cross-platform plugin interface to Airship's iOS and Android native SDKs. This allows core Airship functionality to be implemented by Flutter apps written in dart. The available core Airship functionality currently includes: push, in-app message, message center, actions, custom events and more."
 version: 4.2.0
 homepage: https://www.airship.com/
+repository: https://github.com/urbanairship/airship-flutter
+issue_tracker: https://github.com/urbanairship/airship-flutter/issues
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION

### What do these changes do?

Add repo and issues links to [`pub.dev/packages/airship_flutter`](https://pub.dev/packages/airship_flutter)

### Why are these changes necessary?

It's difficult to find the repository for the package on pub.dev
