### PR TITLE
GH-115: Add support for takeOff directly from dart

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,4 +52,5 @@ dependencies {
     implementation "com.urbanairship.android:urbanairship-message-center:$airship_version"
     implementation "com.urbanairship.android:urbanairship-automation:$airship_version"
     implementation "com.urbanairship.android:urbanairship-preference-center:$airship_version"
+    implementation "androidx.datastore:datastore-preferences:1.0.0"
 }

--- a/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
+++ b/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
@@ -111,7 +111,7 @@ class FlutterInboxMessageView(private var context: Context, channel: MethodChann
             result.error("AIRSHIP_GROUNDED", "Takeoff not called.", null)
             return
         }
-        
+
         val message = MessageCenter.shared().inbox.getMessage(call.arguments())
         if (message != null) {
             webView.loadMessage(message)

--- a/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
+++ b/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
@@ -107,6 +107,11 @@ class FlutterInboxMessageView(private var context: Context, channel: MethodChann
 
     private fun loadMessage(call: MethodCall, result: Result) {
         webviewResult = result
+        if (!(UAirship.isTakingOff() || UAirship.isFlying())) {
+            result.error("AIRSHIP_GROUNDED", "Takeoff not called.", null)
+            return
+        }
+        
         val message = MessageCenter.shared().inbox.getMessage(call.arguments())
         if (message != null) {
             webView.loadMessage(message)

--- a/android/src/main/kotlin/com/airship/flutter/ConfigManager.kt
+++ b/android/src/main/kotlin/com/airship/flutter/ConfigManager.kt
@@ -1,0 +1,81 @@
+package com.airship.flutter
+
+import android.annotation.SuppressLint
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.urbanairship.AirshipConfigOptions
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.single
+
+class ConfigManager(private val context: Context) {
+    companion object {
+        private val APP_KEY = stringPreferencesKey("app_key")
+        private val APP_SECRET = stringPreferencesKey("app_secret")
+
+
+        @SuppressLint("StaticFieldLeak")
+        @Volatile
+        private var instance: ConfigManager? = null
+
+        fun shared(context: Context): ConfigManager = instance ?: synchronized(this) {
+            instance ?: ConfigManager(context.applicationContext).also { instance = it }
+        }
+    }
+
+    private val Context.airshipFlutterPluginStore: DataStore<Preferences> by preferencesDataStore(
+        name = "airshipFlutterPlugin"
+    )
+
+    suspend fun updateConfig(appKey: String, appSecret: String) {
+        withContext(Dispatchers.IO) {
+            context.airshipFlutterPluginStore.edit { preferences ->
+                preferences[APP_KEY] = appKey
+                preferences[APP_SECRET] = appSecret
+            }
+        }
+    }
+
+    val config: Flow<AirshipConfigOptions>
+        get() = flow {
+            withContext(Dispatchers.IO) {
+                val appCredentialsOverride =
+                    context.airshipFlutterPluginStore.data.map { preferences ->
+                        Pair(preferences[APP_KEY], preferences[APP_SECRET])
+                    }.single()
+
+                val config = AirshipConfigOptions.newBuilder()
+                    .applyDefaultProperties(context)
+                    .apply {
+                        if (!(appCredentialsOverride.first.isNullOrEmpty() || appCredentialsOverride.second.isNullOrEmpty())) {
+                            this.setAppKey(appCredentialsOverride.first)
+                                .setAppSecret(appCredentialsOverride.second)
+                                .build()
+                        }
+                    }
+                    .build()
+
+                emit(config)
+            }
+        }
+}
+
+
+fun AirshipConfigOptions.isValid(): Boolean {
+    if (this.appKey.isNullOrEmpty() || this.appSecret.isNullOrEmpty()) {
+        return false
+    }
+
+    return try {
+        validate()
+        true
+    } catch (e: IllegalArgumentException) {
+        false
+    }
+}

--- a/android/src/main/kotlin/com/airship/flutter/EventManager.kt
+++ b/android/src/main/kotlin/com/airship/flutter/EventManager.kt
@@ -2,14 +2,11 @@ package com.airship.flutter
 
 import com.airship.flutter.events.Event
 import com.airship.flutter.events.EventType
-import com.urbanairship.json.JsonValue
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.EventChannel
-import io.flutter.plugin.common.PluginRegistry
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-
 
 class EventManager {
 

--- a/android/src/main/kotlin/com/airship/flutter/Extensions.kt
+++ b/android/src/main/kotlin/com/airship/flutter/Extensions.kt
@@ -4,7 +4,6 @@ import android.os.Build
 import android.os.Bundle
 import android.service.notification.StatusBarNotification
 import androidx.annotation.RequiresApi
-import com.urbanairship.analytics.CustomEvent
 import com.urbanairship.json.JsonMap
 import com.urbanairship.push.NotificationInfo
 import com.urbanairship.push.PushMessage

--- a/android/src/main/kotlin/com/airship/flutter/FlutterAutopilot.kt
+++ b/android/src/main/kotlin/com/airship/flutter/FlutterAutopilot.kt
@@ -12,12 +12,17 @@ import com.urbanairship.push.*
 import com.urbanairship.push.notifications.AirshipNotificationProvider
 import com.urbanairship.push.notifications.NotificationArguments
 import androidx.annotation.XmlRes
+import com.urbanairship.AirshipConfigOptions
 import com.urbanairship.analytics.Analytics
 import com.urbanairship.channel.AirshipChannelListener
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.runBlocking
 
 const val PUSH_MESSAGE_BUNDLE_EXTRA = "com.urbanairship.push_bundle"
 
 class FlutterAutopilot : Autopilot() {
+    var config: AirshipConfigOptions? = null
+
     override fun onAirshipReady(airship: UAirship) {
         super.onAirshipReady(airship)
 
@@ -115,4 +120,21 @@ class FlutterAutopilot : Autopilot() {
     }
 
     private fun post(event: Event) = EventManager.shared.notifyEvent(event)
+
+    override fun isReady(context: Context): Boolean {
+        val config = runBlocking {
+            ConfigManager.shared(context).config.single()
+        }
+
+        return if (config.isValid()) {
+            this.config = config
+            true
+        } else {
+            false
+        }
+    }
+
+    override fun createAirshipConfigOptions(context: Context): AirshipConfigOptions? {
+        return config
+    }
 }

--- a/android/src/main/kotlin/com/airship/flutter/FlutterAutopilot.kt
+++ b/android/src/main/kotlin/com/airship/flutter/FlutterAutopilot.kt
@@ -15,7 +15,11 @@ import androidx.annotation.XmlRes
 import com.urbanairship.AirshipConfigOptions
 import com.urbanairship.analytics.Analytics
 import com.urbanairship.channel.AirshipChannelListener
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.flow.singleOrNull
 import kotlinx.coroutines.runBlocking
 
 const val PUSH_MESSAGE_BUNDLE_EXTRA = "com.urbanairship.push_bundle"
@@ -122,8 +126,8 @@ class FlutterAutopilot : Autopilot() {
     private fun post(event: Event) = EventManager.shared.notifyEvent(event)
 
     override fun isReady(context: Context): Boolean {
-        val config = runBlocking {
-            ConfigManager.shared(context).config.single()
+        val config = runBlocking(Dispatchers.IO) {
+            ConfigManager.shared(context).config.first()
         }
 
         return if (config.isValid()) {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -37,7 +37,6 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.urbanairship.sample"
         minSdkVersion 21
         targetSdkVersion 31

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
-            android:exported="false"
+            android:exported="true"
             android:windowSoftInputMode="adjustResize">
             <!-- This keeps the window background of the activity showing
                  until Flutter renders its first frame. It can be removed if

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -2,20 +2,20 @@ buildscript {
     ext.kotlin_version = '1.5.31'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.2'
+        classpath 'com.android.tools.build:gradle:7.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.google.gms:google-services:4.3.0'  // Google Services plugin
+        classpath 'com.google.gms:google-services:4.3.10'  // Google Services plugin
     }
 }
 
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
-android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=true

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>8.0</string>
+  <string>9.0</string>
 </dict>
 </plist>

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -170,7 +170,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1120;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "The Chromium Authors";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1120"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ios/Classes/AirshipAutopilot.swift
+++ b/ios/Classes/AirshipAutopilot.swift
@@ -1,0 +1,48 @@
+import Flutter
+import AirshipKit
+
+@objc(FlutterAirshipAutopilot)
+public class AirshipAutopilot: NSObject {
+    
+    @objc
+    public static var launchOptions: [UIApplication.LaunchOptionsKey : Any]?
+
+    @objc
+    public static func attempTakeOff() {
+        if (Airship.isFlying) {
+            return
+        }
+        
+        let config = Config.default()
+        config.developmentAppKey = config.developmentAppKey ?? PluginConfig.appKey
+        config.developmentAppSecret = config.developmentAppSecret ?? PluginConfig.appSecret
+
+        config.productionAppKey = config.productionAppKey ?? PluginConfig.appKey
+        config.productionAppSecret = config.productionAppSecret ?? PluginConfig.appSecret
+        
+        guard config.validate() else {
+            return
+        }
+        
+        Airship.takeOff(config, launchOptions: self.launchOptions)
+        Airship.analytics.registerSDKExtension(SDKExtension.flutter, version: AirshipPluginVersion.pluginVersion)
+        Airship.push.defaultPresentationOptions = [.alert]
+        AirshipAutopilot.loadCustomNotificationCategories()
+        
+        SwiftAirshipPlugin.shared.onAirshipReady()
+    }
+    
+    private static func onAirshipReady() {
+       
+    }
+    
+    private static func loadCustomNotificationCategories() {
+        guard let categoriesPath = Bundle.main.path(forResource: "UACustomNotificationCategories", ofType: "plist") else { return }
+        let customNotificationCategories = NotificationCategories.createCategories(fromFile: categoriesPath)
+
+        if customNotificationCategories.count != 0 {
+            Airship.push.customCategories = customNotificationCategories
+            Airship.push.updateRegistration()
+        }
+    }
+}

--- a/ios/Classes/AirshipAutopilot.swift
+++ b/ios/Classes/AirshipAutopilot.swift
@@ -8,7 +8,7 @@ public class AirshipAutopilot: NSObject {
     public static var launchOptions: [UIApplication.LaunchOptionsKey : Any]?
 
     @objc
-    public static func attempTakeOff() {
+    public static func attemptTakeOff() {
         if (Airship.isFlying) {
             return
         }
@@ -28,14 +28,9 @@ public class AirshipAutopilot: NSObject {
         Airship.analytics.registerSDKExtension(SDKExtension.flutter, version: AirshipPluginVersion.pluginVersion)
         Airship.push.defaultPresentationOptions = [.alert]
         AirshipAutopilot.loadCustomNotificationCategories()
-        
         SwiftAirshipPlugin.shared.onAirshipReady()
     }
-    
-    private static func onAirshipReady() {
-       
-    }
-    
+
     private static func loadCustomNotificationCategories() {
         guard let categoriesPath = Bundle.main.path(forResource: "UACustomNotificationCategories", ofType: "plist") else { return }
         let customNotificationCategories = NotificationCategories.createCategories(fromFile: categoriesPath)

--- a/ios/Classes/AirshipEventHandler.swift
+++ b/ios/Classes/AirshipEventHandler.swift
@@ -1,0 +1,84 @@
+import Flutter
+import AirshipKit
+
+public class AirshipEventHandler: NSObject,
+                                  RegistrationDelegate,
+                                  DeepLinkDelegate,
+                                  PushNotificationDelegate,
+                                  MessageCenterDisplayDelegate {
+    func register() {
+        Airship.push.registrationDelegate = self
+        Airship.shared.deepLinkDelegate = self
+        Airship.push.pushNotificationDelegate = self
+        MessageCenter.shared.displayDelegate = self
+        
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(inboxUpdated),
+                                               name: NSNotification.Name.UAInboxMessageListUpdated,
+                                               object: nil)
+    }
+    
+    // MARK: - RegistrationDelegate
+    public func registrationSucceeded(forChannelID channelID: String, deviceToken: String) {
+        let event = AirshipChannelRegistrationEvent(channelID, registrationToken: deviceToken)
+        AirshipEventManager.shared.notify(event)
+    }
+    
+    // MARK: - DeepLinkDelegate
+    public func receivedDeepLink(_ url: URL, completionHandler: @escaping () -> Void) {
+        let event = AirshipDeepLinkEvent(url.absoluteString)
+        AirshipEventManager.shared.notify(event)
+        completionHandler()
+    }
+
+    // MARK: - PushNotificationDelegate
+    public func receivedForegroundNotification(_ userInfo:[AnyHashable : Any], completionHandler: @escaping () -> Void) {
+        let event = AirshipPushReceivedEvent(userInfo)
+        AirshipEventManager.shared.notify(event)
+        completionHandler()
+    }
+
+    public func receivedBackgroundNotification(_ userInfo:[AnyHashable : Any], completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+        let event = AirshipPushReceivedEvent(userInfo)
+        AirshipEventManager.shared.notify(event)
+        completionHandler(.noData)
+    }
+
+    public func receivedNotificationResponse(_ notificationResponse: UNNotificationResponse, completionHandler: @escaping () -> Void) {
+        let event = AirshipNotificationResponseEvent(notificationResponse)
+        AirshipEventManager.shared.notify(event)
+        completionHandler()
+    }
+
+    // MARK: - MessageCenterDisplayDelegate
+    public func displayMessageCenter(forMessageID messageID: String, animated: Bool) {
+        self.showMessage(forID: messageID)
+    }
+
+    public func displayMessageCenter(animated: Bool) {
+        self.showInbox()
+    }
+
+    public func dismissMessageCenter(animated: Bool) {
+        //
+    }
+    
+    @objc
+    public func showInbox() {
+        let event = AirshipShowInboxEvent()
+        AirshipEventManager.shared.notify(event)
+    }
+    
+    @objc
+    public func showMessage(forID messageID: String) {
+        let event = AirshipShowInboxMessageEvent(messageID)
+        AirshipEventManager.shared.notify(event)
+    }
+
+    @objc
+    public func inboxUpdated() {
+        let event = AirshipInboxUpdatedEvent()
+        AirshipEventManager.shared.notify(event)
+    }
+}
+

--- a/ios/Classes/AirshipEventManager.swift
+++ b/ios/Classes/AirshipEventManager.swift
@@ -5,10 +5,10 @@ class AirshipEventManager {
 
     static let shared = AirshipEventManager()
 
-    let streams: [AirshipEventType:AirshipEventStream]
+    let streams: [AirshipEventType: AirshipEventStream]
 
     init() {
-        var streams: [AirshipEventType:AirshipEventStream] = [:]
+        var streams: [AirshipEventType: AirshipEventStream] = [:]
 
         AirshipEventType.allCases.forEach { (eventType) in
             streams[eventType] = AirshipEventStream(eventType)

--- a/ios/Classes/AirshipInboxMessageView.swift
+++ b/ios/Classes/AirshipInboxMessageView.swift
@@ -64,7 +64,20 @@ class AirshipInboxMessageView : NSObject, FlutterPlatformView, NativeBridgeDeleg
     private func loadMessage(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         webviewResult = result
         channel.invokeMethod("onLoadStarted", arguments: nil)
-        let messageId = call.arguments as! String
+        guard let messageId = call.arguments as? String else {
+            result(FlutterError(code:"InvalidArgument",
+                             message:"Must be a message ID")
+                             details:nil))
+            return
+        }
+        
+        guard Airship.isFlying else {
+            result(FlutterError(code:"AIRSHIP_GROUNDED",
+                             message:"Takeoff not called.")
+                             details:nil))
+            return
+        }
+        
         if let message = MessageCenter.shared.messageList.message(forID: messageId) {
             var request = URLRequest(url: message.messageBodyURL)
             let user = MessageCenter.shared.user

--- a/ios/Classes/AirshipInboxMessageView.swift
+++ b/ios/Classes/AirshipInboxMessageView.swift
@@ -57,7 +57,7 @@ class AirshipInboxMessageView : NSObject, FlutterPlatformView, NativeBridgeDeleg
         default:
             result(FlutterError(code:"UNAVAILABLE",
                                 message:"Unknown method: \(call.method)",
-                details:nil))
+                                details:nil))
         }
     }
 
@@ -65,16 +65,16 @@ class AirshipInboxMessageView : NSObject, FlutterPlatformView, NativeBridgeDeleg
         webviewResult = result
         channel.invokeMethod("onLoadStarted", arguments: nil)
         guard let messageId = call.arguments as? String else {
-            result(FlutterError(code:"InvalidArgument",
-                             message:"Must be a message ID")
-                             details:nil))
+            result(FlutterError(code: "InvalidArgument",
+                                message: "Must be a message ID",
+                                details:nil))
             return
         }
         
         guard Airship.isFlying else {
-            result(FlutterError(code:"AIRSHIP_GROUNDED",
-                             message:"Takeoff not called.")
-                             details:nil))
+            result(FlutterError(code: "AIRSHIP_GROUNDED",
+                                message: "Takeoff not called.",
+                                details: nil))
             return
         }
         

--- a/ios/Classes/AirshipPlugin.m
+++ b/ios/Classes/AirshipPlugin.m
@@ -14,7 +14,7 @@
            
            FlutterAirshipAutopilot.launchOptions = note.userInfo;
            
-           [FlutterAirshipAutopilot attempTakeOff];
+           [FlutterAirshipAutopilot attemptTakeOff];
     }];
 }
 @end

--- a/ios/Classes/AirshipPlugin.m
+++ b/ios/Classes/AirshipPlugin.m
@@ -12,7 +12,9 @@
                                                          object:nil
                                                           queue:nil usingBlock:^(NSNotification * _Nonnull note) {
            
-           [SwiftAirshipPlugin takeOffWithLaunchOptions:note.userInfo];
+           FlutterAirshipAutopilot.launchOptions = note.userInfo;
+           
+           [FlutterAirshipAutopilot attempTakeOff];
     }];
 }
 @end

--- a/ios/Classes/PluginConfig.swift
+++ b/ios/Classes/PluginConfig.swift
@@ -1,0 +1,30 @@
+import Foundation
+import AirshipKit
+
+class PluginConfig {
+    
+    private enum Keys : String {
+        case appKey
+        case appSecret
+    }
+    
+    private static let defaults = UserDefaults(suiteName: "com.urbanairship.flutter")!
+    
+    static var appKey: String? {
+        get { return read(.appKey) }
+        set { write(.appKey, value: newValue) }
+    }
+    
+    static var appSecret: String? {
+        get { return read(.appSecret) }
+        set { write(.appSecret, value: newValue) }
+    }
+    
+    private static func read<T>(_ key: Keys) -> T? {
+        return defaults.object(forKey: key.rawValue) as? T
+    }
+    
+    private static func write(_ key: Keys, value: Any?) {
+        defaults.set(value, forKey: key.rawValue)
+    }
+}

--- a/ios/Classes/SwiftAirshipPlugin.swift
+++ b/ios/Classes/SwiftAirshipPlugin.swift
@@ -48,8 +48,8 @@ public class SwiftAirshipPlugin: NSObject, FlutterPlugin {
         }
         
         guard (Airship.isFlying) else {
-            result(FlutterError(code:"AIRSHIP_NOT_READY",
-                              message:"Takeoff must be called before accesing Airship.",
+            result(FlutterError(code:"AIRSHIP_GROUNDED",
+                              message:"TakeOff not called.",
                                details: nil))
             return
         }

--- a/ios/Classes/SwiftAirshipPlugin.swift
+++ b/ios/Classes/SwiftAirshipPlugin.swift
@@ -41,7 +41,6 @@ public class SwiftAirshipPlugin: NSObject, FlutterPlugin {
     
     // MARK: - handle methods call
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-        
         if (call.method == "takeOff") {
             takeOff(call, result: result)
             return
@@ -158,7 +157,7 @@ public class SwiftAirshipPlugin: NSObject, FlutterPlugin {
         
         PluginConfig.appKey = args["app_key"]
         PluginConfig.appSecret = args["app_secret"]
-        AirshipAutopilot.attempTakeOff()
+        AirshipAutopilot.attemptTakeOff()
         
         result(Airship.isFlying)
     }

--- a/lib/src/airship_flutter.dart
+++ b/lib/src/airship_flutter.dart
@@ -155,6 +155,14 @@ class Airship {
     return _eventStreams[eventType];
   }
 
+  static Future<bool> takeOff(String appKey, String appSecret) async {
+    Map<String, String> args = {
+      "app_key": appKey,
+      "app_secret": appSecret
+    };
+    return await _channel.invokeMethod('takeOff', args);
+  }
+
   static Future<String?> get channelId async {
     return await _channel.invokeMethod('getChannelId');
   }


### PR DESCRIPTION
Adds a new `takeOff` method that you can pass the app key and secret into.  The credentials are combined with the config in the plist/properties file. Release/Debug credentials set in the config will take precedents, so in order to use this the app has to remove appkey/secret from the config before calling takeOff. Updates to the config after will not take until the next app init.

I tested on both iOS and Android using the sample App. I launched the app with normal config to see that it worked. I then removed the app key/secret and assigned it to a button click. I navigated the app to make sure we dont have any crashes, then I pressed the takeOff button to verify everything works. Next app launch everything worked before the takeOff button.