### PR TITLE
[GH-120] Allow null or empty string to clear named user

### DIFF
--- a/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
+++ b/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
@@ -394,12 +394,18 @@ class AirshipPlugin : MethodCallHandler, FlutterPlugin {
     }
 
     private fun setNamedUser(call: MethodCall, result: Result) {
-        UAirship.shared().namedUser.id = call.arguments as String?
+        val arg = call.arguments as String?
+        if (arg.isNullOrEmpty()) {
+            UAirship.shared().contact.reset()
+        } else {
+            UAirship.shared().contact.identify(arg)
+        }
+
         result.success(null)
     }
 
     private fun getNamedUser(result: Result) {
-        result.success(UAirship.shared().namedUser.id)
+        result.success(UAirship.shared().contact.namedUserId)
     }
 
     private fun setUserNotificationsEnabled(call: MethodCall, result: Result) {

--- a/ios/Classes/SwiftAirshipPlugin.swift
+++ b/ios/Classes/SwiftAirshipPlugin.swift
@@ -360,12 +360,14 @@ public class SwiftAirshipPlugin: NSObject, FlutterPlugin {
     }
 
     private func setNamedUser(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-        guard let namedUser = call.arguments as? String else {
+        let namedUser = call.arguments as? String
+        
+        if let namedUser = namedUser, !namedUser.isEmpty {
+            Airship.contact.identify(namedUser)
+        } else {
             Airship.contact.reset()
-            result(nil)
-            return
         }
-        Airship.contact.identify(namedUser)
+
         result(nil)
     }
 

--- a/lib/src/airship_flutter.dart
+++ b/lib/src/airship_flutter.dart
@@ -223,7 +223,7 @@ class Airship {
     return TagGroupEditor('editNamedUserTagGroups', _channel);
   }
 
-  static Future<void> setNamedUser(String namedUser) async {
+  static Future<void> setNamedUser(String? namedUser) async {
     return await _channel.invokeMethod('setNamedUser', namedUser);
   }
 


### PR DESCRIPTION
On iOS we were only clearing named user (contact reset) when the value is null and not checking for empty. On Android it was using the deprecated named user APIs so it was fine, but I updated to also use contact so its doing the proper check now as well.