### PR TITLE
fix flutter plugin release ci.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           cp ~/.pub-cache/credentials.json $PUB_CACHE/credentials.json
 
       - name: Publish Dart/Flutter package
-        run: pub publish -f
+        run: flutter pub publish -f
 
       - name: Github Release
         uses: actions/create-release@v1.0.1


### PR DESCRIPTION
Live fix the flutter release actions.
Seems pub is no longer a global command as it used to be.


<!--

Please fill out this template when submitting an pull request.

All lines beginning with an ℹ symbol indicate information that's
important for you to provide to ensure your pull request is reviewed
as quickly and efficiently as possible.

-->

### What do these changes do?
<!-- ℹ Please provide a description of your changes here. -->
Makes possible to run `flutter pub publish -f` in the release action
### Why are these changes necessary?
<!-- ℹ Please provide a concise description of why your changes are
necessary here. -->
`pub` is no longer a global command as it may have been in the previous version.
prefixing it with flutter/dart is necessary e.i `flutter pub publish`
### How did you verify these changes?
<!-- ℹ Please provide any relevant steps to verify or test your work. Make
this description clear enough so someone unfamiliar with your work could
verify for you. -->

#### Verification Screenshots:
<!-- ℹ If applicable, please provide screenshots here. -->
`flutter pub publish --dry-run`
### Anything else a reviewer should know?
<!-- ℹ Please provide any additional notes for the reviewer here. -->
