### PR TITLE
[MOBILE-3171] Patch to fix silent push in background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Flutter Plugin Changelog
 
+## Version 6.0.1 - July 20, 2022
+Patch release that fixes background message handler for silent pushes.
+
 ## Version 6.0.0 - June 13, 2022
 Major release that supports flutter 3.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Flutter Plugin Changelog
 
-## Version 6.0.1 - July 20, 2022
+## Version 6.0.1 - July 21, 2022
 Patch release that fixes background message handler for silent pushes.
 
 ## Version 6.0.0 - June 13, 2022

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Airship Flutter plugin allows using Airship's native iOS and Android APIs wi
 
 ```yaml
 dependencies:
-  airship_flutter: ^6.0.0
+  airship_flutter: ^6.0.1
 ```
 
 2. Install your flutter package dependencies by running the following in the command line at your project's root directory:

--- a/android/src/main/kotlin/com/airship/flutter/AirshipBackgroundExecutor.kt
+++ b/android/src/main/kotlin/com/airship/flutter/AirshipBackgroundExecutor.kt
@@ -118,11 +118,11 @@ class AirshipBackgroundExecutor(
             }
         }
 
-        val eventData = notificationInfo?.eventData()?.toJsonValue() ?: JsonValue.NULL
+        val eventData = notificationInfo?.eventData()?.toJsonValue()?.toString()
         val args = mapOf(
             "messageCallback" to messageCallback,
             "payload" to pushMessage.toJsonValue().toString(),
-            "notification" to eventData.toString()
+            "notification" to eventData
         )
 
         mainHandler.post {

--- a/android/src/main/kotlin/com/airship/flutter/AirshipPluginVersion.kt
+++ b/android/src/main/kotlin/com/airship/flutter/AirshipPluginVersion.kt
@@ -2,6 +2,6 @@ package com.airship.flutter
 
 class AirshipPluginVersion {
     companion object {
-        const val AIRSHIP_PLUGIN_VERSION = "6.0.0"
+        const val AIRSHIP_PLUGIN_VERSION = "6.0.1"
     }
 }

--- a/ios/Classes/AirshipPluginVersion.swift
+++ b/ios/Classes/AirshipPluginVersion.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 class AirshipPluginVersion {
-    static let pluginVersion = "6.0.0"
+    static let pluginVersion = "6.0.1"
 }

--- a/ios/airship_flutter.podspec
+++ b/ios/airship_flutter.podspec
@@ -1,5 +1,5 @@
 
-AIRSHIP_FLUTTER_VERSION="6.0.0"
+AIRSHIP_FLUTTER_VERSION="6.0.1"
 
 #
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: airship_flutter
 description: "Cross-platform plugin interface for the native Airship iOS and Android SDKs. Simplifies adding Airship to Flutter apps."
-version: 6.0.0
+version: 6.0.1
 homepage: https://www.airship.com/
 repository: https://github.com/urbanairship/airship-flutter
 issue_tracker: https://github.com/urbanairship/airship-flutter/issues


### PR DESCRIPTION
### What do these changes do?
Patch version to fix silent push in background.
I updated the notification arg we send to the background message isolate callback.

### Why are these changes necessary?
To fix the background message handler for silent pushes

### How did you verify these changes?
manual tests with a silent push