### PR TITLE
[MOBILE-3182] Return to avoid crash on multiple decisionHandler calls

### DIFF
--- a/ios/Classes/AirshipInboxMessageView.swift
+++ b/ios/Classes/AirshipInboxMessageView.swift
@@ -126,6 +126,7 @@ class AirshipInboxMessageView : NSObject, FlutterPlatformView, NativeBridgeDeleg
                            message:"Unable to load message",
                            details:"Message load failed"))
                 }
+                return
             }
         }
         decisionHandler(.allow)


### PR DESCRIPTION
### What do these changes do?
Return to avoid multiple decisionHandler calls

### Why are these changes necessary?
To fix a crash

### How did you verify these changes?
Manual tests and debug
