### PR TITLE
Annotate background message handler with @pragma('vm:entry-point')

### DIFF
--- a/lib/src/airship_flutter.dart
+++ b/lib/src/airship_flutter.dart
@@ -211,6 +211,7 @@ class PushReceivedEvent {
   }
 }
 
+@pragma('vm:entry-point')
 void _backgroundMessageIsolateCallback() {
   WidgetsFlutterBinding.ensureInitialized();
 


### PR DESCRIPTION
### What do these changes do?
With Flutter 3.3 you have to annotate methods that will be used from native code with `@pragma('vm:entry-point')`. I've added this annotation to `_backgroundMessageIsolateCallback()`.

### Why are these changes necessary?
When you use this plugin with Flutter 3.3 you will get the following error message with release builds.
```
E/flutter (27564): [ERROR:flutter/shell/common/shell.cc(93)] Dart Error: Dart_LookupLibrary:library 'package:airship_flutter/src/airship_flutter.dart' not found.
```
This happens because the compiler does not know that you call this function from native code so it removes it. 

### How did you verify these changes?
Build the example app as release with Flutter 3.3 and view the logs. The error message will be gone.

### Anything else a reviewer should know?

- https://github.com/dart-lang/sdk/blob/master/runtime/docs/compiler/aot/entry_point_pragma.md
- https://github.com/firebase/flutterfire/issues/9446#issuecomment-1240554285
