### PR TITLE
[MOBILE-3542] Fix doc upload and misc warnings in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,17 +35,14 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
 
       - name: Get the release notes
         id: get_release_notes
         run: |
           VERSION=${{ steps.get_version.outputs.VERSION }}
           NOTES="$(awk "/## Version $VERSION/{flag=1;next}/## Version/{flag=0}flag" CHANGELOG.md)"
-          NOTES="${NOTES//'%'/'%25'}"
-          NOTES="${NOTES//$'\n'/'%0A'}"
-          NOTES="${NOTES//$'\r'/'%0D'}"
-          echo ::set-output name=NOTES::"$NOTES"
+          echo "NOTES=${NOTES}" >> $GITHUB_OUTPUT
 
       - uses: actions/setup-java@v2
         with:
@@ -102,7 +99,7 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
 
       - uses: actions/setup-java@v2
         with:
@@ -114,20 +111,22 @@ jobs:
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
 
-      - run: flutter pub get
-
-      - name: Generate documentation
-        run: bash ./scripts/docs.sh -g
-
-      - uses: google-github-actions/setup-gcloud@v0
+      - name: Setup GCP Auth
+        uses: google-github-actions/auth@v1
         with:
-          version: '351.0.0'
-          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
 
-      - name: Upload docs to GoogleCloudPlatform
+      - name: Build & Package docs
         run: |
-          ./scripts/docs.sh -u ${GITHUB_REF/refs\/tags\//} doc/api
+          VERSION=${{ steps.get_version.outputs.VERSION }}
+          flutter pub get
+          bash ./scripts/docs.sh -gp $VERSION doc/api
+
+      - name: Upload docs
+        uses: google-github-actions/upload-cloud-storage@v1
+        with:
+          path: doc/${{ steps.get_version.outputs.VERSION }}.tar.gz
+          destination: ua-web-ci-prod-docs-transfer/libraries/flutter/${{ steps.get_version.outputs.VERSION }}.tar.gz
 
       - name: Slack Notification
         uses: homoluctus/slatify@master

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -8,6 +8,7 @@
 # Options:
 #   -g to generate documentation.
 #   -p to create a tar.gz docs package.
+#   -gp to generate and package documentation.
 #
 #####################################################
 

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -7,7 +7,7 @@
 #
 # Options:
 #   -g to generate documentation.
-#   -u to upload documentation to google cloud.
+#   -p to create a tar.gz docs package.
 #
 #####################################################
 
@@ -16,12 +16,13 @@ set -e
 
 # get platforms
 GENERATE=false
-UPLOAD=false
+PACKAGE=false
 
 while true; do
   case "$1" in
     -g  ) GENERATE=true;;
-    -u  ) UPLOAD=true;;
+    -p  ) PACKAGE=true;;
+    -gp ) GENERATE=true;PACKAGE=true;;
     *   ) break ;;
   esac
   shift
@@ -34,9 +35,8 @@ if $GENERATE; then
   flutter pub global run dartdoc --exclude 'dart:async,dart:collection,dart:convert,dart:core,dart:developer,dart:ffi,dart:html,dart:io,dart:isolate,dart:js,dart:js_util,dart:math,dart:typed_data,dart:ui'
 fi
 
-# Upload doc
-if $UPLOAD; then
-
+# Package doc
+if $PACKAGE; then
     if [ -z "$1" ]; then
         echo "No version supplied"
         exit 1
@@ -47,13 +47,9 @@ if $UPLOAD; then
         exit 1
     fi
 
-    ROOT_PATH=$(dirname "${0}")/..
-    TAR_NAME="$1.tar.gz"
+    TAR_NAME="../$1.tar.gz"
 
     cd "$2"
     tar -czf $TAR_NAME *
     cd -
-
-    gsutil cp "$ROOT_PATH/$2/$TAR_NAME" gs://ua-web-ci-prod-docs-transfer/libraries/flutter/$TAR_NAME
-
 fi


### PR DESCRIPTION
### What do these changes do?

* Tweaks the `docs.sh` script to only build and package docs into `/docs/${VERSION}.tar.gz`. We no longer need it to do the upload, as there's a new action that makes it easy to do from the workflow.
* Updates the workflow to:
    * Use the latest GCP auth and upload actions (should fix the python issue that prevented the docs from uploading in previous releases)
    * Migrate from `::set-output` to `$GITHUB_OUTPUT` to fix warnings

### Why are these changes necessary?

Doc upload step broke and we had some other warnings that needed fixing.

### How did you verify these changes?

Verified the script changes manually, but we'll have to run the release workflow to know for sure.
The GCP action changes were basically identical to changes already made in the Android repo, so I'm not expecting any issues.

