### PR TITLE
[MOBILE-3551] Remove the contact subscription to fix the switch state

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ version '1.0-SNAPSHOT'
 buildscript {  
     ext.kotlin_version = '1.5.31'
     ext.coroutine_version = '1.5.2'
-    ext.airship_version = '16.9.1'
+    ext.airship_version = '16.9.2'
 
     repositories {
         google()

--- a/example/lib/screens/preference_center.dart
+++ b/example/lib/screens/preference_center.dart
@@ -129,9 +129,8 @@ class _PreferenceCenterState extends State<PreferenceCenter>
       title: Text('${item.display.title}',
           style: TextStyle(fontWeight: FontWeight.bold)),
       subtitle: Text('${item.display.subtitle}'),
-      value: isSubscribedContactSubscription(item.subscriptionId, []),
+      value: isSubscribedContactSubscription(item.subscriptionId, ["app"]),
       onChanged: (bool value) {
-        //TODO keep looking in the scopes list
         onPreferenceContactSubscriptionItemToggled(
             item.subscriptionId, ["app"], value);
       },

--- a/example/lib/screens/preference_center.dart
+++ b/example/lib/screens/preference_center.dart
@@ -91,10 +91,11 @@ class _PreferenceCenterState extends State<PreferenceCenter>
     List<String> newScopes = [];
     if (subscribe) {
       newScopes = new List.from(currentScopes)..addAll(scopes);
-      activeContactSubscriptions[subscriptionId] = newScopes;
     } else {
-      activeContactSubscriptions.remove(subscriptionId);
+      currentScopes.removeWhere((scope) => scopes.contains(scope));
+      newScopes = currentScopes;
     }
+    activeContactSubscriptions[subscriptionId] = newScopes;
   }
 
   void onPreferenceContactSubscriptionItemToggled(
@@ -125,14 +126,15 @@ class _PreferenceCenterState extends State<PreferenceCenter>
 
   Widget bindContactSubscriptionItem(
       PreferenceCenterContactSubscriptionItem item) {
+    List<String> scopes = scopesFromComponents(item.scopes);
     return SwitchListTile(
       title: Text('${item.display.title}',
           style: TextStyle(fontWeight: FontWeight.bold)),
       subtitle: Text('${item.display.subtitle}'),
-      value: isSubscribedContactSubscription(item.subscriptionId, ["app"]),
+      value: isSubscribedContactSubscription(item.subscriptionId, scopes),
       onChanged: (bool value) {
         onPreferenceContactSubscriptionItemToggled(
-            item.subscriptionId, scopesFromComponents(item.scopes), value);
+            item.subscriptionId, scopes, value);
       },
     );
   }

--- a/example/lib/screens/preference_center.dart
+++ b/example/lib/screens/preference_center.dart
@@ -132,7 +132,7 @@ class _PreferenceCenterState extends State<PreferenceCenter>
       value: isSubscribedContactSubscription(item.subscriptionId, ["app"]),
       onChanged: (bool value) {
         onPreferenceContactSubscriptionItemToggled(
-            item.subscriptionId, ["app"], value);
+            item.subscriptionId, scopesFromComponents(item.scopes), value);
       },
     );
   }

--- a/example/lib/screens/preference_center.dart
+++ b/example/lib/screens/preference_center.dart
@@ -20,7 +20,7 @@ class _PreferenceCenterState extends State<PreferenceCenter>
     updatePreferenceCenterConfig();
     initAirshipListeners();
     fillInSubscriptionList();
-    Airship.trackScreen('Prefrence Center');
+    Airship.trackScreen('Preference Center');
     super.initState();
   }
 
@@ -91,11 +91,10 @@ class _PreferenceCenterState extends State<PreferenceCenter>
     List<String> newScopes = [];
     if (subscribe) {
       newScopes = new List.from(currentScopes)..addAll(scopes);
+      activeContactSubscriptions[subscriptionId] = newScopes;
     } else {
-      currentScopes.removeWhere((item) => scopes.contains(item));
-      newScopes = currentScopes;
+      activeContactSubscriptions.remove(subscriptionId);
     }
-    activeContactSubscriptions[subscriptionId] = newScopes;
   }
 
   void onPreferenceContactSubscriptionItemToggled(
@@ -132,8 +131,9 @@ class _PreferenceCenterState extends State<PreferenceCenter>
       subtitle: Text('${item.display.subtitle}'),
       value: isSubscribedContactSubscription(item.subscriptionId, []),
       onChanged: (bool value) {
+        //TODO keep looking in the scopes list
         onPreferenceContactSubscriptionItemToggled(
-            item.subscriptionId, [], value);
+            item.subscriptionId, ["app"], value);
       },
     );
   }

--- a/lib/src/preference_center_config.dart
+++ b/lib/src/preference_center_config.dart
@@ -8,6 +8,20 @@ List<Map<String, dynamic>> _toList(dynamic json) {
   return List<Map<String, dynamic>>.from(json);
 }
 
+ChannelScope _parseScope(String scopeString) {
+  switch (scopeString.toLowerCase()) {
+    case "app":
+      return ChannelScope.app;
+    case "web":
+      return ChannelScope.web;
+    case "email":
+      return ChannelScope.email;
+    case "sms":
+      return ChannelScope.sms;
+  }
+  throw Exception("Invalid scope: $scopeString");
+}
+
 /// Preference center config object.
 class PreferenceCenterConfig {
   /// The ID of the preference center.
@@ -432,8 +446,11 @@ class PreferenceCenterContactSubscriptionItem implements PreferenceCenterItem {
   /// The subscription list id.
   final String subscriptionId;
 
+  /// The channel scopes.
+  final List<ChannelScope> scopes;
+
   const PreferenceCenterContactSubscriptionItem._internal(
-      this.display, this.subscriptionId, this.conditions);
+      this.display, this.subscriptionId, this.conditions, this.scopes);
 
   static PreferenceCenterContactSubscriptionItem _fromJson(
       Map<String, dynamic> json) {
@@ -442,13 +459,16 @@ class PreferenceCenterContactSubscriptionItem implements PreferenceCenterItem {
     var conditions = json["conditions"] != null
         ? PreferenceCenterCondition._fromJsonList(_toList(json["conditions"]))
         : null;
+    var scopes = List<String>.from(json["scopes"])
+        .map((scopeString) => _parseScope(scopeString))
+        .toList();
     return PreferenceCenterContactSubscriptionItem._internal(
-        display, subscriptionId, conditions);
+        display, subscriptionId, conditions, scopes);
   }
 
   @override
   String toString() {
-    return "PreferenceCenterContactSubscriptionItem(display=$display, subscriptionId=$subscriptionId, conditions=$conditions)";
+    return "PreferenceCenterContactSubscriptionItem(display=$display, subscriptionId=$subscriptionId, conditions=$conditions, scopes=$scopes)";
   }
 }
 
@@ -477,20 +497,6 @@ class PreferenceCenterContactSubscriptionGroupItemComponent {
 
     return PreferenceCenterContactSubscriptionGroupItemComponent._internal(
         scopes, display);
-  }
-
-  static ChannelScope _parseScope(String scopeString) {
-    switch (scopeString.toLowerCase()) {
-      case "app":
-        return ChannelScope.app;
-      case "web":
-        return ChannelScope.web;
-      case "email":
-        return ChannelScope.email;
-      case "sms":
-        return ChannelScope.sms;
-    }
-    throw Exception("Invalid scope: $scopeString");
   }
 
   @override


### PR DESCRIPTION
Following a customer issue where the Preference center at Contact level does not work properly

### What do these changes do?
Before, when unsubscribing to a list, at a contact level, it only put an empty scope list as value, but the subscriptionId was still in the list.
Since the switch button was checking if the subscriptionId is in the list, the switch stayed enabled

So I made a change to remove the subscriptionId if you unsubscribe to it.

I also added a "app" scope by default, because the SDK does not subscribe if there is no scope in the Contact subscriptions.

### Why are these changes necessary?
To fix the Preference Center in Flutter

### How did you verify these changes?
By running the sample app, and using the "preference_center" id, that is contact level