### PR TITLE
[MOBILE-3542] Fix doc upload path in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,10 +128,10 @@ jobs:
           bash ./scripts/docs.sh -gp $VERSION doc/api
 
       - name: Upload docs
-        uses: google-github-actions/upload-cloud-storage@v1
-        with:
-          path: doc/${{ steps.get_version.outputs.VERSION }}.tar.gz
-          destination: ua-web-ci-prod-docs-transfer/libraries/flutter/${{ steps.get_version.outputs.VERSION }}.tar.gz
+        env:
+            VERSION: ${{ steps.get_version.outputs.VERSION }}
+        run: |
+          gsutil cp doc/$VERSION.tar.gz gs://ua-web-ci-prod-docs-transfer/libraries/flutter/$VERSION.tar.gz
 
       - name: Slack Notification
         uses: homoluctus/slatify@master


### PR DESCRIPTION
### What do these changes do?

Switches back to using `gsutil` for doc uploads, because the fancy action doesn't give as much control over the upload path and file name.

### Why are these changes necessary?

The doc bundle for the last release ended up at the wrong path.

