### PR TITLE
Patch release 6.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Flutter Plugin Changelog
 
 ## Version 6.3.2 - May 19, 2023
-Patch release that updates the intl package dependence minimum version to 0.18.0.
+Patch release that updates the intl package dependency to support versions `>=0.15.7 <1.0.0`.
+Apps upgrading to Flutter 3.10.0 and higher should update.
 
 ## Version 6.3.1 - April 28, 2023 
 Patch release that updates the Android SDK to 16.9.2 and fixes an issue with contact subscriptions 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Flutter Plugin Changelog
 
+## Version 6.3.2 - May 19, 2023
+Patch release that updates the intl package dependence minimum version to 0.18.0.
+
 ## Version 6.3.1 - April 28, 2023 
 Patch release that updates the Android SDK to 16.9.2 and fixes an issue with contact subscriptions 
 in the example Preference Center.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Airship Flutter plugin allows using Airship's native iOS and Android APIs wi
 
 ```yaml
 dependencies:
-  airship_flutter: ^6.3.1
+  airship_flutter: ^6.3.2
 ```
 
 2. Install your flutter package dependencies by running the following in the command line at your project's root directory:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  intl: ">=0.18.0"
+  intl: "^0.18.0"
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  intl: "^0.18.0"
+  intl: '>=0.15.7 <1.0.0'
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: airship_flutter
 description: "Cross-platform plugin interface for the native Airship iOS and Android SDKs. Simplifies adding Airship to Flutter apps."
-version: 6.3.1
+version: 6.3.2
 homepage: https://www.airship.com/
 repository: https://github.com/urbanairship/airship-flutter
 issue_tracker: https://github.com/urbanairship/airship-flutter/issues
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  intl: ">=0.15.7 <0.18.0"
+  intl: ">=0.18.0"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### What do these changes do?
Bump the minimal version of intl to >=0.18.0 make it compatible SDK 3.10.0

### Why are these changes necessary?
So a customer can use Flutter SDK 3.10.0

### How did you verify these changes?
By running the sample app and testing it