### PR TITLE
Release 7.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Flutter Plugin Changelog
 
-## Version 7.0.1 - September 13, 2023
-Patch release that fixes the iOS resetBadge method and updates to latest SDK versions.
+## Version 7.1.0 - September 13, 2023
+Minor release that fixes the iOS resetBadge method, updates to latest SDK versions, and adds a new `editTags` method to batch tag changes.
 
-### 
+### Changes
 - Fixed Airship.push.ios.resetBadge()
 - Updated Android SDK to 17.2.1
 - Updated iOS SDK to 17.3.0
+- Added `editTags()` method to batch tag changes
 
 ## Version 7.0.0 - August 21, 2023
 Major release that exposes significantly more of the underlying SDK functionality to Flutter. This release has several breaking changes due to the new modular APIs. Apps should use the migration guide to update [Migration Guide](https://github.com/urbanairship/airship-flutter/blob/main/MIGRATION.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Flutter Plugin Changelog
 
 ## Version 7.0.1 - September 13, 2023
-Patch release that adds the iOS method `Airship.push.iOS.resetBadge`
+Patch release that fixes the iOS resetBadge method and updates to latest SDK versions.
+
+### 
+- Fixed Airship.push.ios.resetBadge()
+- Updated Android SDK to 17.2.1
+- Updated iOS SDK to 17.3.0
 
 ## Version 7.0.0 - August 21, 2023
 Major release that exposes significantly more of the underlying SDK functionality to Flutter. This release has several breaking changes due to the new modular APIs. Apps should use the migration guide to update [Migration Guide](https://github.com/urbanairship/airship-flutter/blob/main/MIGRATION.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Flutter Plugin Changelog
 
+## Version 7.0.1 - September 13, 2023
+Patch release that adds the iOS method `Airship.push.iOS.resetBadge`
+
 ## Version 7.0.0 - August 21, 2023
 Major release that exposes significantly more of the underlying SDK functionality to Flutter. This release has several breaking changes due to the new modular APIs. Apps should use the migration guide to update [Migration Guide](https://github.com/urbanairship/airship-flutter/blob/main/MIGRATION.md).
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ version '1.0-SNAPSHOT'
 buildscript {  
     ext.kotlin_version = '1.5.31'
     ext.coroutine_version = '1.5.2'
-    ext.airship_version = '17.2.0'
+    ext.airship_version = '17.2.1'
 
     repositories {
         google()
@@ -55,6 +55,6 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutine_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutine_version"
     implementation "com.urbanairship.android:urbanairship-fcm:$airship_version"
-    api "com.urbanairship.android:airship-framework-proxy:4.1.0"
+    api "com.urbanairship.android:airship-framework-proxy:4.2.0"
     implementation "androidx.datastore:datastore-preferences:1.0.0"
 }

--- a/ios/Classes/SwiftAirshipPlugin.swift
+++ b/ios/Classes/SwiftAirshipPlugin.swift
@@ -228,6 +228,9 @@ public class SwiftAirshipPlugin: NSObject, FlutterPlugin {
             
         case "push#ios#isAutobadgeEnabled":
             return try AirshipProxy.shared.push.isAutobadgeEnabled()
+        
+        case "push#ios#resetBadgeNumber":
+            return try AirshipProxy.shared.push.setBadgeNumber(0)
             
         case "push#ios#setNotificationOptions":
             try AirshipProxy.shared.push.setNotificationOptions(

--- a/ios/airship_flutter.podspec
+++ b/ios/airship_flutter.podspec
@@ -20,6 +20,6 @@ Airship flutter plugin.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.ios.deployment_target      = "14.0"
-  s.dependency "AirshipFrameworkProxy", "4.1.0"
+  s.dependency "AirshipFrameworkProxy", "4.2.0"
 end
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: airship_flutter
 description: "Cross-platform plugin interface for the native Airship iOS and Android SDKs. Simplifies adding Airship to Flutter apps."
-version: 7.0.0
+version: 7.0.1
 homepage: https://www.airship.com/
 repository: https://github.com/urbanairship/airship-flutter
 issue_tracker: https://github.com/urbanairship/airship-flutter/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: airship_flutter
 description: "Cross-platform plugin interface for the native Airship iOS and Android SDKs. Simplifies adding Airship to Flutter apps."
-version: 7.0.1
+version: 7.1.0
 homepage: https://www.airship.com/
 repository: https://github.com/urbanairship/airship-flutter
 issue_tracker: https://github.com/urbanairship/airship-flutter/issues


### PR DESCRIPTION
### What do these changes do?
Adds the `Airship.push.iOS.resetBadge` that got unfortunately removed, and changes the versions to prepare for hotfix release

### Why are these changes necessary?
To have all the methods available

### How did you verify these changes?
Running the sample app and testing
