### PR TITLE
Fix release ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+*"
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_15.0.1app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_15.0.1.app/Contents/Developer
   FLUTTER_VERSION: 3.0.2
   JAVA_VERSION: "12.x"
   JAVA_DISTRIBUTION: 'zulu'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.airship.airship'
 version '1.0-SNAPSHOT'
 
 buildscript {  
-    ext.kotlin_version = '1.7.1'
+    ext.kotlin_version = '1.7.10'
     ext.coroutine_version = '1.5.2'
     ext.datastore_preferences_version = '1.0.0'
     ext.airship_version = '17.2.1'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.airship.airship'
 version '1.0-SNAPSHOT'
 
 buildscript {  
-    ext.kotlin_version = '1.5.31'
+    ext.kotlin_version = '1.7.1'
     ext.coroutine_version = '1.5.2'
     ext.datastore_preferences_version = '1.0.0'
     ext.airship_version = '17.2.1'


### PR DESCRIPTION
### Addresses a couple issues in release ci:

- Fixes a typo in the DEVELOPER_DIR to address the following:
```
Cannot find "xcodebuild". Xcode 13 or greater is required to develop for iOS.
Encountered error while building for device.

```
- Updates Kotlin to address the following:
```
e: /Users/runner/work/airship-flutter/airship-flutter/example/build/airship_flutter/.transforms/5311bca21027a3e31527fed45aa0e1e9/transformed/out/jars/classes.jar!/META-INF/airship_flutter_release.kotlin_module: Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.7.1, expected version is 1.5.1.
e: /Users/runner/.gradle/caches/transforms-3/fe9e40ada0c61d8faedb147178a80e05/transformed/jetified-airship-framework-proxy-5.0.2/jars/classes.jar!/META-INF/airship-framework-proxy_release.kotlin_module: Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.7.1, expected version is 1.5.1.
...
```

