### PR TITLE
Release 7.3.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # https://help.github.com/en/articles/about-code-owners
-*       @BrianBatchelder @marc-scig @crow @rlepinski
+*       @jyaganeh @Apekka @crow @rlepinski @khmMouna @Ulirco972 @oristanovic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Flutter Plugin Changelog
 
+## Version 7.3.0 - December 6, 2023
+Minor release that updates the iOS SDK to 17.7.0 and Android SDK to 17.6.0 and adds support for notifying the contact of a remote login.
+
+### Changes
+- Updated iOS SDK to 17.7.0
+- Updated Android SDK to 17.6.0
+- Added `Airship.contactManager.notifyRemoteLogin()` method to notify contact of remote login
+
 ## Version 7.2.0 - November 27, 2023
 Minor release that improves Feature Flag support on iOS.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Minor release that updates the iOS SDK to 17.7.0 and Android SDK to 17.6.0 and a
 ### Changes
 - Updated iOS SDK to 17.7.0
 - Updated Android SDK to 17.6.0
-- Added `Airship.contactManager.notifyRemoteLogin()` method to notify contact of remote login
+- Added `Airship.contact.notifyRemoteLogin()` method to notify contact of remote login
 
 ## Version 7.2.0 - November 27, 2023
 Minor release that improves Feature Flag support on iOS.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,8 +5,8 @@ buildscript {
     ext.kotlin_version = '1.7.10'
     ext.coroutine_version = '1.5.2'
     ext.datastore_preferences_version = '1.0.0'
-    ext.airship_version = '17.2.1'
-    ext.airship_framework_proxy_version = '5.0.2'
+    ext.airship_version = '17.6.0'
+    ext.airship_framework_proxy_version = '5.1.0'
 
     repositories {
         google()

--- a/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
+++ b/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
@@ -134,6 +134,7 @@ class AirshipPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
             // Contact
             "contact#reset" -> result.resolveResult(call) { proxy.contact.reset() }
+            "contact#notifyRemoteLogin" -> result.resolveResult(call) { proxy.contact.notifyRemoteLogin() }
             "contact#identify" -> result.resolveResult(call) { proxy.contact.identify(call.stringArg()) }
             "contact#getNamedUserId" -> result.resolveResult(call) { proxy.contact.getNamedUserId() }
             "contact#editTagGroups" -> result.resolveResult(call) { proxy.contact.editTagGroups(call.jsonArgs()) }

--- a/android/src/main/kotlin/com/airship/flutter/AirshipPluginVersion.kt
+++ b/android/src/main/kotlin/com/airship/flutter/AirshipPluginVersion.kt
@@ -2,6 +2,6 @@ package com.airship.flutter
 
 class AirshipPluginVersion {
     companion object {
-        const val AIRSHIP_PLUGIN_VERSION = "7.2.0"
+        const val AIRSHIP_PLUGIN_VERSION = "7.3.0"
     }
 }

--- a/ios/Classes/AirshipPluginVersion.swift
+++ b/ios/Classes/AirshipPluginVersion.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 class AirshipPluginVersion {
-    static let pluginVersion = "7.2.0"
+    static let pluginVersion = "7.3.0"
 }

--- a/ios/Classes/SwiftAirshipPlugin.swift
+++ b/ios/Classes/SwiftAirshipPlugin.swift
@@ -182,6 +182,10 @@ public class SwiftAirshipPlugin: NSObject, FlutterPlugin {
             try AirshipProxy.shared.contact.reset()
             return nil
         
+        case "contact#notifyRemoteLogin":
+            try AirshipProxy.shared.contact.notifyRemoteLogin()
+            return nil
+
         case "contact#getNamedUserId":
             return try await AirshipProxy.shared.contact.getNamedUser()
         

--- a/ios/airship_flutter.podspec
+++ b/ios/airship_flutter.podspec
@@ -1,5 +1,5 @@
 
-AIRSHIP_FLUTTER_VERSION="7.2.0"
+AIRSHIP_FLUTTER_VERSION="7.3.0"
 
 #
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
@@ -20,6 +20,6 @@ Airship flutter plugin.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.ios.deployment_target      = "14.0"
-  s.dependency "AirshipFrameworkProxy", "5.2.0"
+  s.dependency "AirshipFrameworkProxy", "5.1.0"
 end
 

--- a/ios/airship_flutter.podspec
+++ b/ios/airship_flutter.podspec
@@ -20,6 +20,6 @@ Airship flutter plugin.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.ios.deployment_target      = "14.0"
-  s.dependency "AirshipFrameworkProxy", "5.0.2"
+  s.dependency "AirshipFrameworkProxy", "5.2.0"
 end
 

--- a/lib/src/airship_contact.dart
+++ b/lib/src/airship_contact.dart
@@ -42,6 +42,11 @@ class AirshipContact {
     return await _module.channel.invokeMethod('contact#reset');
   }
 
+    /// Notifies the contact of a remote login.
+  Future<void> notifyRemoteLogin() async {
+    return await _module.channel.invokeMethod('contact#notifyRemoteLogin');
+  }
+
   /// Creates an [AttributeEditor] to modify the named user attributes.
   AttributeEditor editAttributes() {
     return AttributeEditor('contact#editAttributes', _module.channel);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: airship_flutter
 description: "Cross-platform plugin interface for the native Airship iOS and Android SDKs. Simplifies adding Airship to Flutter apps."
-version: 7.2.0
+version: 7.3.0
 homepage: https://www.airship.com/
 repository: https://github.com/urbanairship/airship-flutter
 issue_tracker: https://github.com/urbanairship/airship-flutter/issues


### PR DESCRIPTION
<!--

Please fill out this template when submitting an pull request.

All lines beginning with an ℹ symbol indicate information that's
important for you to provide to ensure your pull request is reviewed
as quickly and efficiently as possible.

-->

### What do these changes do?
Minor release that updates the iOS SDK to 17.7.0 and Android SDK to 17.6.0 and adds support for notifying the contact of a remote login.

- Updated iOS SDK to 17.7.0
- Updated Android SDK to 17.6.0
- Added `Airship.contactManager.notifyRemoteLogin()` method to notify contact of remote login


### Why are these changes necessary?
🚀

### How did you verify these changes?
Set breakpoints on the new notifyRemoteLogin method and ensured these breakpoints were hit.

#### Verification Screenshots:
![image](https://github.com/urbanairship/airship-flutter/assets/2199816/c15a53cf-09f6-4bb4-9c50-bd218ff5273d)
![image](https://github.com/urbanairship/airship-flutter/assets/2199816/85b8010f-f034-46f8-bffd-2f243d63a969)