### PR TITLE
[MOBILE-4148] Fix gradle 8 build issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Flutter Plugin Changelog
 
+## Version 7.3.1 - February 16, 2024
+Patch release that fixes a build issue when using Android Gradle Plugin 8+.
+
+### Changes
+- Added a namespace to the Airship module.
+
 ## Version 7.3.0 - December 6, 2023
 Minor release that updates the iOS SDK to 17.7.0 and Android SDK to 17.6.0 and adds support for notifying the contact of a remote login.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,6 +44,7 @@ android {
         disable 'InvalidPackage'
     }
 
+    namespace = 'com.airship.airship'
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,7 +15,7 @@ buildscript {
 
     dependencies {
         classpath 'org.yaml:snakeyaml:1.17'
-        classpath 'com.android.tools.build:gradle:7.0.0'
+        classpath 'com.android.tools.build:gradle:7.0.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -31,7 +31,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 33
+    compileSdk 34
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.airship.airship">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
         <meta-data android:name="com.urbanairship.autopilot"

--- a/android/src/main/kotlin/com/airship/flutter/AirshipPluginVersion.kt
+++ b/android/src/main/kotlin/com/airship/flutter/AirshipPluginVersion.kt
@@ -2,6 +2,6 @@ package com.airship.flutter
 
 class AirshipPluginVersion {
     companion object {
-        const val AIRSHIP_PLUGIN_VERSION = "7.3.0"
+        const val AIRSHIP_PLUGIN_VERSION = "7.3.1"
     }
 }

--- a/ios/Classes/AirshipPluginVersion.swift
+++ b/ios/Classes/AirshipPluginVersion.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 class AirshipPluginVersion {
-    static let pluginVersion = "7.3.0"
+    static let pluginVersion = "7.3.1"
 }

--- a/ios/airship_flutter.podspec
+++ b/ios/airship_flutter.podspec
@@ -1,5 +1,5 @@
 
-AIRSHIP_FLUTTER_VERSION="7.3.0"
+AIRSHIP_FLUTTER_VERSION="7.3.1"
 
 #
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: airship_flutter
 description: "Cross-platform plugin interface for the native Airship iOS and Android SDKs. Simplifies adding Airship to Flutter apps."
-version: 7.3.0
+version: 7.3.1
 homepage: https://www.airship.com/
 repository: https://github.com/urbanairship/airship-flutter
 issue_tracker: https://github.com/urbanairship/airship-flutter/issues


### PR DESCRIPTION
### What do these changes do?
Add a namespace to our flutter module

### Why are these changes necessary?
To fix a build issue due to the use of gradle 8.

### How did you verify these changes?
Reproduced on the flutter sample.
