### PR TITLE
Add compileOptions to fix new flutter release warning

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,6 +43,10 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
 
     namespace = 'com.airship.airship'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,6 +32,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdk 34
+    compileSdkVersion 34
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'


### PR DESCRIPTION
### What do these changes do?
I've updated the sourceCompatibility and targetCompatibility for Java in the build.gradle file.

### Why are these changes necessary?
These changes are necessary since Flutter has updated its version and we have a warning in the console. Without this change, we can't update the configuration.

```txt
You are applying Flutter's app_plugin_loader Gradle plugin imperatively using the apply script method, which is deprecated and will be removed in a future release. Migrate to applying Gradle plugins with the declarative plugins block: https://flutter.dev/go/flutter-gradle-plugin-apply

You are applying Flutter's main Gradle plugin imperatively using the apply script method, which is deprecated and will be removed in a future release. Migrate to applying Gradle plugins with the declarative plugins block: https://flutter.dev/go/flutter-gradle-plugin-apply
```

### How did you verify these changes?
I used my package instead of the pub.dev one.

```txt
✓ Built build/app/outputs/flutter-apk/app-staging-debug.apk
```

### Anything else a reviewer should know?
I'm open to discussion if you need more information.
