### PR TITLE
Prepare version 7.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Flutter Plugin Changelog
 
+## Version 7.7.0 - August 07, 2024
+Minor release that updates Android SDK to 18.1.5 and iOS SDK to 18.7.1 and fixes test devices audience check and holdout group experiments displays.
+
+### Changes
+- Updated Android SDK to 18.1.5.
+- Updated iOS SDK to 18.7.1.
+- Fixed test devices audience check.
+- Fixed holdout group experiments displays.
+
 ## Version 7.6.0 - July 11, 2024
 Minor release that updates the Android SDK to 18.1.1 and the iOS SDK to 18.5.0.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,8 +7,8 @@ buildscript {
     ext.kotlin_version = '1.9.0'
     ext.coroutine_version = '1.5.2'
     ext.datastore_preferences_version = '1.1.1'
-    ext.airship_version = '18.1.1'
-    ext.airship_framework_proxy_version = '7.0.0'
+    ext.airship_version = '18.1.5'
+    ext.airship_framework_proxy_version = '7.1.1'
 
     repositories {
         google()

--- a/android/src/main/kotlin/com/airship/flutter/AirshipPluginVersion.kt
+++ b/android/src/main/kotlin/com/airship/flutter/AirshipPluginVersion.kt
@@ -2,6 +2,6 @@ package com.airship.flutter
 
 class AirshipPluginVersion {
     companion object {
-        const val AIRSHIP_PLUGIN_VERSION = "7.6.0"
+        const val AIRSHIP_PLUGIN_VERSION = "7.7.0"
     }
 }

--- a/ios/Classes/AirshipPluginVersion.swift
+++ b/ios/Classes/AirshipPluginVersion.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 class AirshipPluginVersion {
-    static let pluginVersion = "7.6.0"
+    static let pluginVersion = "7.7.0"
 }

--- a/ios/airship_flutter.podspec
+++ b/ios/airship_flutter.podspec
@@ -1,5 +1,5 @@
 
-AIRSHIP_FLUTTER_VERSION="7.6.0"
+AIRSHIP_FLUTTER_VERSION="7.7.0"
 
 #
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
@@ -20,6 +20,6 @@ Airship flutter plugin.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.ios.deployment_target      = "14.0"
-  s.dependency "AirshipFrameworkProxy", "7.0.0"
+  s.dependency "AirshipFrameworkProxy", "7.1.1"
 end
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: airship_flutter
 description: "Cross-platform plugin interface for the native Airship iOS and Android SDKs. Simplifies adding Airship to Flutter apps."
-version: 7.6.0
+version: 7.7.0
 homepage: https://www.airship.com/
 repository: https://github.com/urbanairship/airship-flutter
 issue_tracker: https://github.com/urbanairship/airship-flutter/issues


### PR DESCRIPTION
### What do these changes do?
updates the framework proxy

### Why are these changes necessary?
to get android's patch in

### How did you verify these changes?


#### Verification Screenshots:


### Anything else a reviewer should know?
I can't test the latest versions of our iOS SDK from that macbook (too old version of MacOS).
Could someone test iOS please ?
