### PR TITLE
Fix message center message retrieval when launched from mc push

### DIFF
--- a/ios/Classes/AirshipInboxMessageView.swift
+++ b/ios/Classes/AirshipInboxMessageView.swift
@@ -86,7 +86,7 @@ class AirshipInboxMessageView : NSObject, FlutterPlatformView, NativeBridgeDeleg
 
         if message == nil {
             /// Attempt a refresh is the message isn't available - as can happen when launched from a push
-            let success = try? await inbox.refreshMessages(timeout: 5)
+            let success = try? await inbox.refreshMessages(timeout: 100)
 
             /// If message is nil and we fail to refresh, throw error
             if success == false {


### PR DESCRIPTION
### What do these changes do?
Attempts a refresh when launching an MC message from a push. Similar to what we do in the react-native plugin.

### Why are these changes necessary?
To resolve some preventable message open failures.

### How did you verify these changes?
Tested with and without the change launching the message center from an MC-containing push.