### PR TITLE
fix: add swift version to podspec for flutter module compatibility

### DIFF
--- a/ios/airship_flutter.podspec
+++ b/ios/airship_flutter.podspec
@@ -21,5 +21,6 @@ Airship flutter plugin.
   s.dependency 'Flutter'
   s.ios.deployment_target      = "14.0"
   s.dependency "AirshipFrameworkProxy", "11.0.4"
+  s.swift_version = "5.0.0"
 end
 


### PR DESCRIPTION
Hi,
Can you please merge this pull request. (It is required when using flutter module)
  `s.swift_version = "5.0.0"`
Thank you