### PR TITLE
Fix areNotificationsAllowed retrieval on Android

### DIFF
--- a/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
+++ b/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
@@ -176,9 +176,14 @@ class AirshipPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 }
             }
             "push#isUserNotificationsEnabled" -> result.resolveResult(call) { proxy.push.isUserNotificationsEnabled() }
-            "push#getNotificationStatus" -> result.resolveResult(call) {
+            "push#getNotificationStatus" -> result.resolveDeferred(call) { callback ->
                 coroutineScope.launch {
-                    proxy.push.getNotificationStatus()
+                    try {
+                        val status = proxy.push.getNotificationStatus()
+                        callback(status, null)
+                    } catch (e: Exception) {
+                        callback(null, e)
+                    }
                 }
             }
             "push#getActiveNotifications" -> result.resolveResult(call) {

--- a/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
+++ b/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
@@ -277,22 +277,7 @@ class AirshipPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             }
             // Live Activities
 
-            "featureFlagManager#trackInteraction" -> {
-                result.resolveDeferred(call) { callback ->
-                    scope.launch {
-                        try {
-                            val args = call.jsonArgs()
 
-                            val wrapped = JsonValue.wrap(args)
-                            val featureFlagProxy = FeatureFlagProxy(wrapped)
-                            proxy.featureFlagManager.trackInteraction(flag = featureFlagProxy)
-                            callback(null, null)
-                        } catch (e: Exception) {
-                            callback(null, e)
-                        }
-                    }
-                }
-            }
 
             "liveUpdate#start" -> result.resolveResult(call) {
                 try {


### PR DESCRIPTION
### What do these changes do?
Fixes the push status method by using resolveDeferred instead of resolveResult so that the coroutine can complete and the serializable status can be sent back.

Also removes a duplicate implementation for feature flags trackInteraction method.

### Why are these changes necessary?
The push status method isn't functioning as it should. The original implementation was returning a coroutine directly through the platform channel which isn't serializable. 

### How did you verify these changes?
Isolated the issue and reproduced the exception, then making the fix and testing the retrieval flow on launch:
https://gist.github.com/crow/6bdebcb6f04155ca2d3978c9e891db31