### PR TITLE
[EUCUST-125] Remove duplicate resolve

### DIFF
--- a/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
+++ b/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
@@ -304,11 +304,8 @@ class AirshipPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             // Feature Flag
             "featureFlagManager#flag" -> result.resolve(scope, call) {
                 val args = call.jsonArgs().requireMap()
-                val flagName = args.get("flagName")?.requireString()
+                val flagName = requireNotNull(args.get("flagName")?.requireString())
                 val useResultCache = args.get("useResultCache")?.getBoolean(false) ?: false
-                if (flagName == null) {
-                    throw Exception("Missing flagName")
-                }
                 proxy.featureFlagManager.flag(flagName, useResultCache)
             }
 
@@ -325,9 +322,8 @@ class AirshipPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 val args = call.jsonArgs().requireMap()
                 val flag = FeatureFlagProxy(JsonValue.wrap(args.get("flag")?.requireString()?.toMap()))
                 val ttl = args.get("ttl")?.getLong(0)
-                val miliseconds = ttl?.milliseconds ?: throw Exception("Missing ttl")
-                proxy.featureFlagManager.resultCache.cache(flag, miliseconds)
-
+                val milliseconds = requireNotNull(ttl?.milliseconds)
+                proxy.featureFlagManager.resultCache.cache(flag, milliseconds)
             }
 
             "featureFlagManager#resultCacheRemoveFlag" -> result.resolve(scope, call) {


### PR DESCRIPTION
### What do these changes do?
Remove the resolve function call in the feature flag part of the plugin.

### Why are these changes necessary?
Following an EU escalation, where the customer had crashes if the app was in airplane mode, it couldn't get the feature flags, and also couldn't catch the exception to avoid the crash.
cf logs : 
<img width="572" height="252" alt="image" src="https://github.com/user-attachments/assets/3b58ec45-9e4d-43d4-b662-65fe72ddc5d3" />
This happened cause we were calling twice result.error (in AirshipPlugin.kt and in Extensions.kt)

### How did you verify these changes?
Running in the sample app, with airplane mode and trying to catch the exception of a feature flag, it works properly now we only have logs and the app can still function.

```
E/AirshipPlugin(30247): Error processing featureFlag#flag
E/AirshipPlugin(30247): com.urbanairship.featureflag.FeatureFlagException$FailedToFetch: Failed to fetch feature flag: 'rad_flag'! Stale data is not allowed.
```
