### PR TITLE
[TEST] Release 10.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Flutter Plugin Changelog
 
+## Version 10.10.2 - December 16, 2025
+
+Patch release that updates the Android SDK to  and the iOS SDK to .
+
+### Changes
+- Updated Android SDK to [](https://github.com/urbanairship/android-library/releases/tag/)
+- Updated iOS SDK to [](https://github.com/urbanairship/ios-library/releases/tag/)
+
+
 ## Version 10.10.1 - November 14, 2025
 
 Patch release that fixes YouTube video playback in In-App Automation and Scenes. Applications that use YouTube videos in Scenes and non-html In-App Automations (IAA) must update to resolve playback errors.
@@ -28,7 +37,7 @@ Minor release that updates the Android SDK to 19.13.4 and the iOS SDK to 19.11.0
 ## Version 10.8.0 - August 28, 2025
 Minor release that updates the Android SDK to 19.11.0 and the iOS SDK to 19.8.3.
 
-### 
+###
 - Updated Android SDK to [19.11.0](https://github.com/urbanairship/android-library/releases/tag/19.11.0)
 - Updated iOS SDK to [19.8.3](https://github.com/urbanairship/ios-library/releases/tag/19.8.3)
 - Updated Android event emitting to wait for an attached activity for all events but background push recieved.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_version = '1.9.0'
     ext.coroutine_version = '1.5.2'
     ext.datastore_preferences_version = '1.1.1'
-    ext.airship_framework_proxy_version = '14.10.1'
+    ext.airship_framework_proxy_version = '15.0.3'
 
 
     repositories {

--- a/android/src/main/kotlin/com/airship/flutter/AirshipPluginVersion.kt
+++ b/android/src/main/kotlin/com/airship/flutter/AirshipPluginVersion.kt
@@ -2,6 +2,6 @@ package com.airship.flutter
 
 class AirshipPluginVersion {
     companion object {
-        const val AIRSHIP_PLUGIN_VERSION = "10.10.1"
+        const val AIRSHIP_PLUGIN_VERSION = "10.10.2"
     }
 }

--- a/ios/airship_flutter.podspec
+++ b/ios/airship_flutter.podspec
@@ -1,5 +1,5 @@
 
-AIRSHIP_FLUTTER_VERSION="10.10.1"
+AIRSHIP_FLUTTER_VERSION="10.10.2"
 
 #
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
@@ -19,7 +19,7 @@ Airship flutter plugin.
   s.source_files = 'airship_flutter/Sources/airship_flutter/**/*'
   s.dependency 'Flutter'
   s.ios.deployment_target      = "15.0"
-  s.dependency "AirshipFrameworkProxy", "14.10.1"
+  s.dependency "AirshipFrameworkProxy", "15.0.3"
   s.swift_version = "5.0.0"
   s.resource_bundles = {'airship_flutter_privacy' => ['airship_flutter/Sources/airship_flutter/PrivacyInfo.xcprivacy']}
 end

--- a/ios/airship_flutter/Sources/airship_flutter/AirshipPluginVersion.swift
+++ b/ios/airship_flutter/Sources/airship_flutter/AirshipPluginVersion.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 class AirshipPluginVersion {
-    static let pluginVersion = "10.10.1"
+    static let pluginVersion = "10.10.2"
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: airship_flutter
 description: "Cross-platform plugin interface for the native Airship iOS and Android SDKs. Simplifies adding Airship to Flutter apps."
-version: 10.10.1
+version: 10.10.2
 homepage: https://www.airship.com/
 repository: https://github.com/urbanairship/airship-flutter
 issue_tracker: https://github.com/urbanairship/airship-flutter/issues


### PR DESCRIPTION
Automated release preparation for Flutter v10.10.2

## Version Updates
- Plugin: 10.10.2
- Framework Proxy: 15.0.3
- iOS SDK: not specified
- Android SDK: not specified

## Validation Reminder
⚠️ **Note:** Since this release updates the underlying native SDKs, the changelog entries across all framework plugins will be similar. This is expected and correct.

## Changed Files
```
CHANGELOG.md
android/build.gradle
android/src/main/kotlin/com/airship/flutter/AirshipPluginVersion.kt
ios/airship_flutter.podspec
ios/airship_flutter/Sources/airship_flutter/AirshipPluginVersion.swift
pubspec.yaml
```

## Next Steps
1. Review version updates
2. Verify changelog accuracy
3. Merge when ready

---
🤖 Generated by centralized release automation