### PR TITLE
Extract docs publishing into a reusable shared workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,73 @@
+name: Publish Docs
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+    secrets:
+      GCP_SA_KEY:
+        required: true
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag to publish docs for (e.g. 12.0.0)'
+        required: true
+        type: string
+
+env:
+  FLUTTER_VERSION: 3.27.3
+
+jobs:
+  release-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.version }}
+
+      - name: Flutter action
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+
+      - name: Setup GCP Auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Build & Package docs
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          bash ./scripts/docs.sh -gp $VERSION doc/api
+
+      - name: Upload docs
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          gsutil cp doc/$VERSION.tar.gz gs://ua-web-ci-prod-docs-transfer/libraries/flutter/$VERSION.tar.gz
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: doc/api
+
+  deploy-docs:
+    needs: release-docs
+    runs-on: ubuntu-latest
+    continue-on-error: true # Remove when migration to GH Pages is complete
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,77 +79,26 @@ jobs:
           draft: false
           prerelease: false
 
-      - name: Slack Notification
-        uses: homoluctus/slatify@master
-        if: failure()
-        with:
-          type: ${{ job.status }}
-          job_name: "Failed to release Flutter :("
-          url: ${{ secrets.MOBILE_SLACK_WEBHOOK }}
-  
-  release-docs:
-    runs-on: macos-26-xlarge
-    needs: [ ci, release-plugin-github, release-plugin-pub-dev ]
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Get the version
-        id: get_version
-        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
-
-      - uses: actions/setup-java@v2
-        with:
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-          java-version: ${{ env.JAVA_VERSION }}
-
-      - name: Flutter action
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-
-      - name: Setup GCP Auth
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-
-      - name: Build & Package docs
-        run: |
-          VERSION=${{ steps.get_version.outputs.VERSION }}
-          flutter pub get
-          bash ./scripts/docs.sh -gp $VERSION doc/api
-
-      - name: Upload docs
-        env:
-            VERSION: ${{ steps.get_version.outputs.VERSION }}
-        run: |
-          gsutil cp doc/$VERSION.tar.gz gs://ua-web-ci-prod-docs-transfer/libraries/flutter/$VERSION.tar.gz
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: doc/api
-
-      - name: Slack Notification
-        uses: homoluctus/slatify@master
-        with:
-          type: ${{ job.status }}
-          job_name: ":raised_hands: Airship Flutter Plugin Released! :raised_hands:"
-          url: ${{ secrets.MOBILE_SLACK_WEBHOOK }}
-
-  deploy-docs:
-    needs: release-docs
-    runs-on: ubuntu-latest
-    continue-on-error: true # Remove when migration to GH Pages is complete
+  publish-docs:
+    needs: [ ci, release-plugin-pub-dev, release-plugin-github ]
     permissions:
+      contents: read
       pages: write
       id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+    uses: ./.github/workflows/publish-docs.yml
+    with:
+      version: ${{ github.ref_name }}
+    secrets: inherit
+
+  notify-release:
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [ ci, release-plugin-pub-dev, release-plugin-github, publish-docs ]
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Slack Notification
+        uses: homoluctus/slatify@master
+        with:
+          # && returns the string if truthy, so || short-circuits on the first match; 'success' is only reached if both contains() checks are false
+          type: ${{ (contains(needs.*.result, 'failure') && 'failure') || (contains(needs.*.result, 'cancelled') && 'cancelled') || 'success' }}
+          job_name: "Flutter Release"
+          url: ${{ secrets.MOBILE_SLACK_WEBHOOK }}


### PR DESCRIPTION
## Summary

- Extracts `release-docs` and `deploy-docs` from `release.yml` into a new reusable workflow `.github/workflows/publish-docs.yml`
- The shared workflow can be triggered automatically via `workflow_call` from the release pipeline, or manually via `workflow_dispatch` for a specific tagged version
- Consolidates Slack notifications into a single `notify-release` job that covers success, failure, and cancellation across all pipeline jobs

## Test plan

- [ ] Verify a tag push runs the full release pipeline and the `publish-docs` shared workflow is called correctly
- [ ] Verify a manual `workflow_dispatch` run of Publish Docs with a valid version tag checks out the right code and builds docs
- [ ] Verify the Slack notification fires correctly on success and failure
- [ ] Verify a `deploy-docs` failure (GitHub Pages not yet enabled) does not cause the Slack notification to report failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)