### PR TITLE
Fix notification permission status always returning notDetermined

### DIFF
--- a/lib/src/push_notification_status.dart
+++ b/lib/src/push_notification_status.dart
@@ -41,9 +41,7 @@ class PushNotificationStatus {
     var isOptedIn = json["isOptedIn"] ?? false;
     var isUserOptedIn = json["isUserOptedIn"] ?? false;
     var notificationPermissionStatus =
-        json["notificationPermissionStatus"] is PermissionStatus
-            ? json["notificationPermissionStatus"] as PermissionStatus
-            : PermissionStatus.notDetermined;
+        _parsePermissionStatus(json["notificationPermissionStatus"]);
     return PushNotificationStatus._internal(
         isUserNotificationsEnabled,
         areNotificationsAllowed,
@@ -52,6 +50,18 @@ class PushNotificationStatus {
         isOptedIn,
         isUserOptedIn,
         notificationPermissionStatus);
+  }
+
+  static PermissionStatus _parsePermissionStatus(dynamic value) {
+    switch (value) {
+      case "granted":
+        return PermissionStatus.granted;
+      case "denied":
+        return PermissionStatus.denied;
+      case "not_determined":
+      default:
+        return PermissionStatus.notDetermined;
+    }
   }
 
   @override

--- a/scripts/run_ci_tasks.sh
+++ b/scripts/run_ci_tasks.sh
@@ -47,6 +47,7 @@ flutter packages get
 # Flutter Analysis
 if $ANALYZE; then
     flutter analyze
+    flutter test
     # Perform publish dry run to ensure the package can be published
     dart analyze --fatal-infos
     flutter pub pub publish --dry-run --skip-validation

--- a/test/push_notification_status_test.dart
+++ b/test/push_notification_status_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:airship_flutter/src/push_notification_status.dart';
+
+void main() {
+  Map<String, dynamic> baseJson(String? status) => {
+        "isUserNotificationsEnabled": true,
+        "areNotificationsAllowed": true,
+        "isPushPrivacyFeatureEnabled": true,
+        "isPushTokenRegistered": true,
+        "isOptedIn": true,
+        "isUserOptedIn": true,
+        "notificationPermissionStatus": status,
+      };
+
+  test('parses "granted" from native (snake-case string)', () {
+    final status = PushNotificationStatus.fromJson(baseJson("granted"));
+    expect(status.notificationPermissionStatus, PermissionStatus.granted);
+  });
+
+  test('parses "denied" from native (snake-case string)', () {
+    final status = PushNotificationStatus.fromJson(baseJson("denied"));
+    expect(status.notificationPermissionStatus, PermissionStatus.denied);
+  });
+
+  test('parses "not_determined" from native (snake-case string)', () {
+    final status = PushNotificationStatus.fromJson(baseJson("not_determined"));
+    expect(status.notificationPermissionStatus, PermissionStatus.notDetermined);
+  });
+
+  test('falls back to notDetermined when value is null', () {
+    final status = PushNotificationStatus.fromJson(baseJson(null));
+    expect(status.notificationPermissionStatus, PermissionStatus.notDetermined);
+  });
+
+  test('falls back to notDetermined for unknown values', () {
+    final status = PushNotificationStatus.fromJson(baseJson("garbage"));
+    expect(status.notificationPermissionStatus, PermissionStatus.notDetermined);
+  });
+}


### PR DESCRIPTION
## Summary
- `PushNotificationStatus.fromJson` checked `json["notificationPermissionStatus"] is PermissionStatus`, but the platform channel sends a String (e.g. `"granted"`, `"denied"`, `"not_determined"`). The check was never true, so every status fell through to `PermissionStatus.notDetermined` — even when permissions were granted.
- Parse the native snake_case string explicitly, following the existing pattern in `airship_utils.parseIOSAuthorizedStatus`.
- Add unit tests covering granted / denied / not_determined / null / unknown.
- Wire `flutter test` into `scripts/run_ci_tasks.sh` so the new coverage actually runs on PRs (it wasn't being invoked before).

Fixes #300

## Test plan
- [x] `flutter test` — 5/5 new tests pass
- [x] `flutter analyze` — clean
- [x] Verified failing behavior pre-fix: granted/denied tests fail with `Actual: PermissionStatus.notDetermined`

🤖 Generated with [Claude Code](https://claude.com/claude-code)