### PR TITLE
Release 12.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Flutter Plugin Changelog
 
+## Version 12.1.1 - June 12, 2026
+
+Patch release that updates the Android SDK to 20.7.4 and the iOS SDK to 20.7.2.
+
+### Changes
+- Updated Android SDK to [20.7.4](https://github.com/urbanairship/android-library/releases/tag/20.7.4)
+- Updated iOS SDK to [20.7.2](https://github.com/urbanairship/ios-library/releases/tag/20.7.2)
+
+
 ## Version 12.1.0 - May 28, 2026
 
 Minor release that adds contact email and SMS channel registration.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_version = '2.0.21'
     ext.coroutine_version = '1.5.2'
     ext.datastore_preferences_version = '1.1.1'
-    ext.airship_framework_proxy_version = '15.9.0'
+    ext.airship_framework_proxy_version = '15.9.1'
 
 
 

--- a/android/src/main/kotlin/com/airship/flutter/AirshipPluginVersion.kt
+++ b/android/src/main/kotlin/com/airship/flutter/AirshipPluginVersion.kt
@@ -2,6 +2,6 @@ package com.airship.flutter
 
 class AirshipPluginVersion {
     companion object {
-        const val AIRSHIP_PLUGIN_VERSION = "12.1.0"
+        const val AIRSHIP_PLUGIN_VERSION = "12.1.1"
     }
 }

--- a/ios/airship_flutter.podspec
+++ b/ios/airship_flutter.podspec
@@ -1,5 +1,5 @@
 
-AIRSHIP_FLUTTER_VERSION="12.1.0"
+AIRSHIP_FLUTTER_VERSION="12.1.1"
 
 #
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
@@ -19,7 +19,7 @@ Airship flutter plugin.
   s.source_files = 'airship_flutter/Sources/airship_flutter/**/*'
   s.dependency 'Flutter'
   s.ios.deployment_target      = "16.0"
-  s.dependency "AirshipFrameworkProxy", "15.9.0"
+  s.dependency "AirshipFrameworkProxy", "15.9.1"
   s.swift_version = "5.0.0"
   s.resource_bundles = {'airship_flutter_privacy' => ['airship_flutter/Sources/airship_flutter/PrivacyInfo.xcprivacy']}
 end

--- a/ios/airship_flutter/Sources/airship_flutter/AirshipPluginVersion.swift
+++ b/ios/airship_flutter/Sources/airship_flutter/AirshipPluginVersion.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 class AirshipPluginVersion {
-    static let pluginVersion = "12.1.0"
+    static let pluginVersion = "12.1.1"
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: airship_flutter
 description: "Cross-platform plugin interface for the native Airship iOS and Android SDKs. Simplifies adding Airship to Flutter apps."
-version: 12.1.0
+version: 12.1.1
 homepage: https://www.airship.com/
 repository: https://github.com/urbanairship/airship-flutter
 issue_tracker: https://github.com/urbanairship/airship-flutter/issues


### PR DESCRIPTION
Automated release preparation for Flutter v12.1.1

## Version Updates
- Plugin: 12.1.1
- Framework Proxy: 15.9.1
- iOS SDK: 20.7.2
- Android SDK: 20.7.4

## Validation Reminder
⚠️ **Note:** Since this release updates the underlying native SDKs, the changelog entries across all framework plugins will be similar. This is expected and correct.

## Changed Files
```
CHANGELOG.md
android/build.gradle
android/src/main/kotlin/com/airship/flutter/AirshipPluginVersion.kt
ios/airship_flutter.podspec
ios/airship_flutter/Sources/airship_flutter/AirshipPluginVersion.swift
pubspec.yaml
```

## Next Steps
1. Review version updates
2. Verify changelog accuracy
3. Merge when ready

---
🤖 Generated by centralized release automation