### PR TITLE
Fix native message center rendering in embedded message view

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_version = '2.0.21'
     ext.coroutine_version = '1.5.2'
     ext.datastore_preferences_version = '1.1.1'
-    ext.airship_framework_proxy_version = '15.10.0'
+    ext.airship_framework_proxy_version = '15.11.0'
 
 
 

--- a/android/src/main/kotlin/com/airship/flutter/FlutterInboxMessageView.kt
+++ b/android/src/main/kotlin/com/airship/flutter/FlutterInboxMessageView.kt
@@ -1,14 +1,15 @@
 package com.airship.flutter
 
 import android.content.Context
-import android.graphics.Bitmap
+import android.view.ContextThemeWrapper
 import android.view.View
-import android.webkit.WebView
+import com.airship.airship.R
 import com.urbanairship.Airship
-import com.urbanairship.messagecenter.MessageCenter
-
-import com.urbanairship.messagecenter.ui.widget.MessageWebView
-import com.urbanairship.messagecenter.ui.widget.MessageWebViewClient
+import com.urbanairship.messagecenter.Message
+import com.urbanairship.messagecenter.ui.view.MessageView
+import com.urbanairship.messagecenter.ui.view.MessageViewModel
+import com.urbanairship.messagecenter.ui.view.MessageViewState
+import com.urbanairship.messagecenter.ui.view.bind
 
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -18,45 +19,58 @@ import io.flutter.plugin.common.StandardMessageCodec
 import io.flutter.plugin.platform.PlatformViewFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.plus
 
 class FlutterInboxMessageView(
-    private var context: Context,
+    context: Context,
     channel: MethodChannel
 ) : PlatformView, MethodChannel.MethodCallHandler {
 
+    private val viewModel = MessageViewModel()
+    private val messageView: MessageView = MessageView(
+        ContextThemeWrapper(context, R.style.FlutterAirshipMessageViewTheme)
+    )
+    private val scope: CoroutineScope = CoroutineScope(Dispatchers.Main.immediate) + SupervisorJob()
+    private var currentMessageId: String? = null
     private lateinit var webviewResult: MethodChannel.Result
 
-    private val webView: MessageWebView by lazy {
-        val view = MessageWebView(context)
-        view.webViewClient = object : MessageWebViewClient() {
-            override fun onPageStarted(view: WebView, url: String?, favicon: Bitmap?) {
-                super.onPageStarted(view, url, favicon)
-                channel.invokeMethod("onLoadStarted", null)
-            }
-
-            override fun onPageFinished(view: WebView?, url: String?) {
-                super.onPageFinished(view, url)
+    init {
+        messageView.listener = object : MessageView.Listener {
+            override fun onMessageLoaded(message: Message) {
+                viewModel.markMessagesRead(message)
                 channel.invokeMethod("onLoadFinished", null)
             }
 
-            override fun onClose(webView: WebView) {
-                super.onClose(webView)
-                channel.invokeMethod("onClose", null)
+            override fun onMessageLoadError(error: MessageViewState.Error.Type) {
+                val details = when (error) {
+                    MessageViewState.Error.Type.LOAD_FAILED -> "Message load failed"
+                    MessageViewState.Error.Type.UNAVAILABLE -> "Message not available"
+                }
+                webviewResult.error("InvalidMessage", "Unable to load message", details)
             }
 
-            @Deprecated("Deprecated in Java")
-            override fun onReceivedError(view: WebView?, errorCode: Int, description: String?, failingUrl: String?) {
-                super.onReceivedError(view, errorCode, description, failingUrl)
-                if (errorCode == 410) {
-                    webviewResult.error("InvalidMessage", "Unable to load message", "Message not available")
-                } else {
-                    webviewResult.error("InvalidMessage", "Unable to load message", "Message load failed")
+            override fun onRetryClicked() {
+                currentMessageId?.let { viewModel.loadMessage(it) }
+            }
+
+            override fun onCloseMessage() {
+                channel.invokeMethod("onClose", null)
+            }
+        }
+
+        @Suppress("RestrictedApi")
+        messageView.bind(viewModel, scope)
+
+        scope.launch {
+            viewModel.states.collect { state ->
+                if (state is MessageViewState.Loading) {
+                    channel.invokeMethod("onLoadStarted", null)
                 }
             }
         }
-        view
     }
 
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
@@ -66,10 +80,10 @@ class FlutterInboxMessageView(
         }
     }
 
-    override fun getView(): View = webView
+    override fun getView(): View = messageView
 
     override fun dispose() {
-
+        scope.cancel()
     }
 
     private fun loadMessage(call: MethodCall, result: MethodChannel.Result) {
@@ -79,17 +93,12 @@ class FlutterInboxMessageView(
             return
         }
 
-        CoroutineScope(Dispatchers.IO).launch {
-            val message = MessageCenter.shared().inbox.getMessage(call.arguments())
-            withContext(Dispatchers.Main) {
-                if (message != null) {
-                    webView.loadMessage(message)
-                    message.markRead()
-                } else {
-                    result.error("InvalidMessage", "Unable to load message: ${call.arguments}", null)
-                }
-            }
+        val messageId = call.arguments<String>() ?: run {
+            result.error("InvalidArgument", "Must be a message ID", null)
+            return
         }
+        currentMessageId = messageId
+        viewModel.loadMessage(messageId)
     }
 }
 

--- a/android/src/main/res/values/themes.xml
+++ b/android/src/main/res/values/themes.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="FlutterAirshipMessageViewTheme" parent="Theme.Material3.DayNight.NoActionBar" />
+</resources>

--- a/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/urbanairship/airship-mobile-framework-proxy.git",
       "state" : {
-        "revision" : "712b4908c80d737bb31da883e80e1879384d5048",
-        "version" : "15.7.0"
+        "revision" : "b5abb66684abfaa91806c878f9124342cb0d70ac",
+        "version" : "15.11.0"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/urbanairship/ios-library.git",
       "state" : {
-        "revision" : "60e0385d882f189084e483d191284949323a3e91",
-        "version" : "20.6.2"
+        "revision" : "09570aba6853bab3c7c7d9986973b283eedad91b",
+        "version" : "20.10.0"
       }
     }
   ],

--- a/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/urbanairship/airship-mobile-framework-proxy.git",
       "state" : {
-        "revision" : "712b4908c80d737bb31da883e80e1879384d5048",
-        "version" : "15.7.0"
+        "revision" : "b5abb66684abfaa91806c878f9124342cb0d70ac",
+        "version" : "15.11.0"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/urbanairship/ios-library",
       "state" : {
-        "revision" : "60e0385d882f189084e483d191284949323a3e91",
-        "version" : "20.6.2"
+        "revision" : "09570aba6853bab3c7c7d9986973b283eedad91b",
+        "version" : "20.10.0"
       }
     }
   ],

--- a/ios/airship_flutter.podspec
+++ b/ios/airship_flutter.podspec
@@ -19,7 +19,7 @@ Airship flutter plugin.
   s.source_files = 'airship_flutter/Sources/airship_flutter/**/*'
   s.dependency 'Flutter'
   s.ios.deployment_target      = "16.0"
-  s.dependency "AirshipFrameworkProxy", "15.10.0"
+  s.dependency "AirshipFrameworkProxy", "15.11.0"
   s.swift_version = "5.0.0"
   s.resource_bundles = {'airship_flutter_privacy' => ['airship_flutter/Sources/airship_flutter/PrivacyInfo.xcprivacy']}
 end

--- a/ios/airship_flutter/Package.swift
+++ b/ios/airship_flutter/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "airship-flutter", targets: ["airship_flutter"])
     ],
     dependencies: [
-        .package(url: "https://github.com/urbanairship/airship-mobile-framework-proxy.git", from: "15.10.0")
+        .package(url: "https://github.com/urbanairship/airship-mobile-framework-proxy.git", from: "15.11.0")
     ],
     targets: [
         .target(

--- a/ios/airship_flutter/Sources/airship_flutter/AirshipInboxMessageView.swift
+++ b/ios/airship_flutter/Sources/airship_flutter/AirshipInboxMessageView.swift
@@ -1,5 +1,5 @@
 import Foundation
-import WebKit
+import SwiftUI
 import Flutter
 
 #if canImport(AirshipCore)
@@ -26,43 +26,92 @@ class AirshipInboxMessageViewFactory : NSObject, FlutterPlatformViewFactory {
     }
 }
 
-class AirshipInboxMessageView : NSObject, FlutterPlatformView, NativeBridgeDelegate, WKNavigationDelegate, AirshipWKNavigationDelegate {
-    let webView : WKWebView
-    let nativeBridge = NativeBridge()
-    let channel : FlutterMethodChannel
-    var webviewResult : FlutterResult
+@MainActor
+private class MessageState: ObservableObject {
+    @Published var viewModel: MessageCenterMessageViewModel?
+    @Published var phase: MessageCenterMessageContentPhase = .loading
+    var onClose: (@MainActor @Sendable () -> Void)?
+    var onPhaseChange: (@MainActor (MessageCenterMessageContentPhase) -> Void)?
+}
 
-    init(frame: CGRect, viewId: Int64, registrar: FlutterPluginRegistrar) {
-        self.webView = WKWebView(frame: frame)
-        self.webView.configuration.dataDetectorTypes = [.all]
+private struct MessageContainerView: View {
+    @ObservedObject var state: MessageState
 
-        let channelName = "com.airship.flutter/InboxMessageView_\(viewId)"
-        self.channel = FlutterMethodChannel(name: channelName, binaryMessenger: registrar.messenger())
-        self.webviewResult = { result in print(result!) }
-        
-        super.init()
-
-        self.webView.navigationDelegate = self.nativeBridge
-        self.nativeBridge.forwardNavigationDelegate = self
-        self.nativeBridge.nativeBridgeDelegate = self
-        weak var weakSelf = self
-        channel.setMethodCallHandler { (call, result) in
-            if let strongSelf = weakSelf {
-                Task {
-                    await strongSelf.handle(call, result: result)
-                }
-            } else {
-                result(FlutterError(code:"UNAVAILABLE",
-                                    message:"Instance no longer available",
-                                    details:nil))
+    var body: some View {
+        if let viewModel = state.viewModel {
+            MessageCenterMessageContentView(
+                viewModel: viewModel,
+                phase: $state.phase,
+                dismissAction: state.onClose
+            )
+            .id(viewModel.messageID)
+            .onChange(of: state.phase) { phase in
+                state.onPhaseChange?(phase)
             }
         }
     }
+}
 
-    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) async {
+class AirshipInboxMessageView : UIView, FlutterPlatformView {
+    private let state = MessageState()
+    private let viewController: UIViewController
+    private var isAdded = false
+    private let channel: FlutterMethodChannel
+    private var webviewResult: FlutterResult = { result in print(result!) }
+
+    required init(frame: CGRect, viewId: Int64, registrar: FlutterPluginRegistrar) {
+        let channelName = "com.airship.flutter/InboxMessageView_\(viewId)"
+        self.channel = FlutterMethodChannel(name: channelName, binaryMessenger: registrar.messenger())
+        self.viewController = UIHostingController(rootView: MessageContainerView(state: self.state))
+        self.viewController.view.backgroundColor = .clear
+
+        super.init(frame: frame)
+
+        self.addSubview(self.viewController.view)
+        self.viewController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+
+        self.state.onClose = { [weak self] in
+            self?.channel.invokeMethod("onClose", arguments: nil)
+        }
+
+        self.state.onPhaseChange = { [weak self] phase in
+            guard let self else { return }
+            switch phase {
+            case .loading:
+                break
+            case .loaded:
+                self.channel.invokeMethod("onLoadFinished", arguments: nil)
+                Task { await self.state.viewModel?.markRead() }
+            case .error(let error):
+                let details = error == .messageGone ? "Message not available" : "Message load failed"
+                self.webviewResult(FlutterError(
+                    code: "MessageLoadFailed",
+                    message: "Unable to load message",
+                    details: details
+                ))
+            }
+        }
+
+        weak var weakSelf = self
+        channel.setMethodCallHandler { (call, result) in
+            guard let strongSelf = weakSelf else {
+                result(FlutterError(code:"UNAVAILABLE",
+                                    message:"Instance no longer available",
+                                    details:nil))
+                return
+            }
+            strongSelf.handle(call, result: result)
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
         case "loadMessage":
-            await loadMessage(call, result: result)
+            loadMessage(call, result: result)
         default:
             result(FlutterError(code:"UNAVAILABLE",
                                 message:"Unknown method: \(call.method)",
@@ -70,16 +119,16 @@ class AirshipInboxMessageView : NSObject, FlutterPlatformView, NativeBridgeDeleg
         }
     }
 
-    private func loadMessage(_ call: FlutterMethodCall, result: @escaping FlutterResult) async {
+    private func loadMessage(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         webviewResult = result
-        channel.invokeMethod("onLoadStarted", arguments: nil)
-        guard let messageId = call.arguments as? String else {
+
+        guard let messageID = call.arguments as? String else {
             result(FlutterError(code: "InvalidArgument",
                                 message: "Must be a message ID",
                                 details:nil))
             return
         }
-        
+
         guard Airship.isFlying else {
             result(FlutterError(code: "AIRSHIP_GROUNDED",
                                 message: "Takeoff not called.",
@@ -87,91 +136,23 @@ class AirshipInboxMessageView : NSObject, FlutterPlatformView, NativeBridgeDeleg
             return
         }
 
-        let inbox = Airship.messageCenter.inbox
+        channel.invokeMethod("onLoadStarted", arguments: nil)
 
-        let message = await inbox.message(forID: messageId)
-
-        if message == nil {
-            /// Attempt a refresh is the message isn't available - as can happen when launched from a push
-            let success = try? await inbox.refreshMessages(timeout: 100)
-
-            /// If message is nil and we fail to refresh, throw error
-            if success == false {
-                result(FlutterError(code:"InvalidMessage",
-                                    message:"Unable to load message: \(messageId), message unavailable and message refresh failed.",
-                                    details:nil))
-                return
-            }
-        }
-
-        if let message = await inbox.message(forID: messageId) {
-            var request = URLRequest(url: message.bodyURL)
-            let user = await Airship.messageCenter.inbox.user
-            
-            if let user = user {
-                guard let auth = AirshipUtils.authHeader(username: user.username, password: user.password) else {
-                    result(FlutterError(code:"InvalidState",
-                                        message:"User not created.",
-                                        details:nil))
-                    return
-                }
-                request.addValue(auth, forHTTPHeaderField: "Authorization")
-            
-                await self.webView.load(request)
-                await inbox.markRead(messages: [message])
-                
-            }
-                
-           
-        } else {
-            /// If refresh attempt succeeds and we still don't have a message
-            result(FlutterError(code:"InvalidMessage",
-                                message:"Unable to load message after successful inbox refresh: \(messageId))",
-                                details:nil))
-            return
-        }
-      }
+        state.phase = .loading
+        state.viewModel = MessageCenterMessageViewModel(messageID: messageID)
+    }
 
     func view() -> UIView {
-        return webView
+        return self
     }
 
-    func close() {
-        channel.invokeMethod("onClose", arguments: nil)
-    }
-    
-    func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse,
-                 decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
-
-        if let response = navigationResponse.response as? HTTPURLResponse {
-            if (response.statusCode >= 400 && response.statusCode <= 599) {
-                decisionHandler(.cancel)
-                if (response.statusCode == 410) {
-                    webviewResult(FlutterError(code:"MessageLoadFailed",
-                           message:"Unable to load message",
-                           details:"Message not available"))
-                } else {
-                    webviewResult(FlutterError(code:"MessageLoadFailed",
-                           message:"Unable to load message",
-                           details:"Message load failed"))
-                }
-                return
-            }
-        }
-        decisionHandler(.allow)
-    }
-    
-    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        channel.invokeMethod("onLoadFinished", arguments: nil)
-    }
-    
-    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-        webviewResult(FlutterError(code:"MessageLoadFailed",
-                                   message:"Unable to load message",
-                                   details:error.localizedDescription))
-    }
-    
-    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-        webView.navigationDelegate?.webView?(webView, didFail: navigation, withError: error)
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        guard !isAdded else { return }
+        viewController.willMove(toParent: parentViewController())
+        parentViewController().addChild(viewController)
+        viewController.didMove(toParent: parentViewController())
+        viewController.view.isUserInteractionEnabled = true
+        isAdded = true
     }
 }


### PR DESCRIPTION
### What do these changes do?
Swaps the WebView (Android) and WKWebView (iOS) used by the embedded single-message view for the message view. Bumps AirshipFrameworkProxy to 15.11.0. See [react-native-airship pr #746](https://github.com/urbanairship/react-native-airship/pull/746).

### Why are these changes necessary?
The embedded message view could only render HTML-body messages. Native (Thomas) messages silently failed to display since the old WebView based implementation has no way to render them.

### How did you verify these changes?
Built the example app for both Android (flutter build apk) and iOS (flutter build ios --simulator) against the bumped SDK versions and confirmed both compile clean.

#### Verification Screenshots:
