### PR TITLE
Allow embedded views to size to their content

### DIFF
--- a/android/src/main/kotlin/com/airship/flutter/FlutterEmbeddedView.kt
+++ b/android/src/main/kotlin/com/airship/flutter/FlutterEmbeddedView.kt
@@ -1,9 +1,11 @@
+/* Copyright Airship and Contributors */
+
 package com.airship.flutter
 
 import android.content.Context
-import android.graphics.Color
 import android.view.View
 import android.widget.FrameLayout
+import android.widget.ScrollView
 import com.urbanairship.embedded.AirshipEmbeddedSelection
 import com.urbanairship.embedded.AirshipEmbeddedView
 import io.flutter.plugin.common.BinaryMessenger
@@ -12,37 +14,72 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.StandardMessageCodec
 import io.flutter.plugin.platform.PlatformView
 import io.flutter.plugin.platform.PlatformViewFactory
+import kotlin.math.abs
 
 class FlutterEmbeddedView(
-    private var context: Context,
+    private val context: Context,
     private val channel: MethodChannel,
     private val embeddedId: String,
-    private val selection: AirshipEmbeddedSelection
+    private val selection: AirshipEmbeddedSelection,
+    private val parentHeight: Double?
 ) : PlatformView, MethodChannel.MethodCallHandler {
 
-    private val frameLayout: FrameLayout = FrameLayout(context)
-    private var airshipEmbeddedView: AirshipEmbeddedView? = null
+    // Without an explicit height, the content is hosted in a scroll view so it measures
+    // against an unconstrained height instead of the height Flutter imposes.
+    private val selfSizing: Boolean = parentHeight == null
+
+    private val container: FrameLayout = if (selfSizing) {
+        ScrollView(context).apply {
+            clipChildren = false
+            isVerticalScrollBarEnabled = false
+        }
+    } else {
+        FrameLayout(context)
+    }
+
+    private val airshipEmbeddedView = AirshipEmbeddedView(context, embeddedId, selection = selection)
+    private val density: Float = context.resources.displayMetrics.density
+    private var reportedHeight: Double = -1.0
 
     init {
         setupAirshipEmbeddedView()
         channel.setMethodCallHandler(this)
     }
-    private fun setupAirshipEmbeddedView() {
 
-        airshipEmbeddedView = AirshipEmbeddedView(context, embeddedId, selection = selection)
-        airshipEmbeddedView?.layoutParams = FrameLayout.LayoutParams(
+    private fun setupAirshipEmbeddedView() {
+        airshipEmbeddedView.layoutParams = FrameLayout.LayoutParams(
             FrameLayout.LayoutParams.MATCH_PARENT,
-            FrameLayout.LayoutParams.MATCH_PARENT
+            if (selfSizing) {
+                FrameLayout.LayoutParams.WRAP_CONTENT
+            } else {
+                FrameLayout.LayoutParams.MATCH_PARENT
+            }
         )
-        frameLayout.addView(airshipEmbeddedView)
+        container.addView(airshipEmbeddedView)
+
+        if (selfSizing) {
+            // Percent sized content has no parent height to resolve against, so use the display.
+            val displayHeight = context.resources.displayMetrics.heightPixels
+            airshipEmbeddedView.parentHeightProvider = { displayHeight }
+
+            airshipEmbeddedView.addOnLayoutChangeListener { view, _, _, _, _, _, _, _, _ ->
+                reportContentHeight(view.measuredHeight / density.toDouble())
+            }
+        }
+    }
+
+    private fun reportContentHeight(height: Double) {
+        if (abs(height - reportedHeight) <= 0.5) return
+        reportedHeight = height
+        channel.invokeMethod("onSizeUpdate", mapOf("height" to height))
     }
 
     override fun getView(): View {
-        frameLayout.layoutParams = FrameLayout.LayoutParams(
+        container.layoutParams = FrameLayout.LayoutParams(
             FrameLayout.LayoutParams.MATCH_PARENT,
             FrameLayout.LayoutParams.MATCH_PARENT
         )
-        return frameLayout
+        return container
     }
 
     override fun dispose() {
@@ -68,8 +105,9 @@ class EmbeddedViewFactory(
         val params = args as? Map<*, *>
         val embeddedId = params?.get("embeddedId") as? String ?: "defaultId"
         val selection = parseSelection(params?.get("selection") as? Map<*, *>)
+        val parentHeight = (params?.get("parentHeight") as? Number)?.toDouble()
 
-        return FlutterEmbeddedView(checkNotNull(context), channel, embeddedId, selection)
+        return FlutterEmbeddedView(checkNotNull(context), channel, embeddedId, selection, parentHeight)
     }
 
     private fun parseSelection(selection: Map<*, *>?): AirshipEmbeddedSelection {

--- a/android/src/main/kotlin/com/airship/flutter/FlutterEmbeddedView.kt
+++ b/android/src/main/kotlin/com/airship/flutter/FlutterEmbeddedView.kt
@@ -4,6 +4,7 @@ package com.airship.flutter
 
 import android.content.Context
 import android.view.View
+import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.ScrollView
 import com.urbanairship.embedded.AirshipEmbeddedSelection
@@ -21,32 +22,40 @@ class FlutterEmbeddedView(
     private val channel: MethodChannel,
     private val embeddedId: String,
     private val selection: AirshipEmbeddedSelection,
-    private val parentHeight: Double?
+    selfSizing: Boolean
 ) : PlatformView, MethodChannel.MethodCallHandler {
 
-    // Without an explicit height, the content is hosted in a scroll view so it measures
-    // against an unconstrained height instead of the height Flutter imposes.
-    private val selfSizing: Boolean = parentHeight == null
-
-    private val container: FrameLayout = if (selfSizing) {
-        ScrollView(context).apply {
-            clipChildren = false
-            isVerticalScrollBarEnabled = false
-        }
-    } else {
-        FrameLayout(context)
-    }
+    // Stable view handed to Flutter. The container inside it is rebuilt when the
+    // sizing mode changes, so the view Flutter holds never has to be replaced.
+    private val root = FrameLayout(context)
 
     private val airshipEmbeddedView = AirshipEmbeddedView(context, embeddedId, selection = selection)
     private val density: Float = context.resources.displayMetrics.density
     private var reportedHeight: Double = -1.0
+    private var selfSizing: Boolean = selfSizing
+
+    private val layoutChangeListener =
+        View.OnLayoutChangeListener { view, _, _, _, _, _, _, _, _ ->
+            reportContentHeight(view.measuredHeight / density.toDouble())
+        }
 
     init {
-        setupAirshipEmbeddedView()
+        root.layoutParams = FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT,
+            FrameLayout.LayoutParams.MATCH_PARENT
+        )
+        applyContainer()
         channel.setMethodCallHandler(this)
     }
 
-    private fun setupAirshipEmbeddedView() {
+    // Rebuilds the hierarchy for the current mode. Self sizing hosts the content in
+    // a scroll view so it measures against an unconstrained height; measurement and
+    // the display-based percent fallback apply only in that mode.
+    private fun applyContainer() {
+        (airshipEmbeddedView.parent as? ViewGroup)?.removeView(airshipEmbeddedView)
+        root.removeAllViews()
+        airshipEmbeddedView.removeOnLayoutChangeListener(layoutChangeListener)
+
         airshipEmbeddedView.layoutParams = FrameLayout.LayoutParams(
             FrameLayout.LayoutParams.MATCH_PARENT,
             if (selfSizing) {
@@ -55,17 +64,35 @@ class FlutterEmbeddedView(
                 FrameLayout.LayoutParams.MATCH_PARENT
             }
         )
-        container.addView(airshipEmbeddedView)
 
         if (selfSizing) {
-            // Percent sized content has no parent height to resolve against, so use the display.
-            val displayHeight = context.resources.displayMetrics.heightPixels
-            airshipEmbeddedView.parentHeightProvider = { displayHeight }
-
-            airshipEmbeddedView.addOnLayoutChangeListener { view, _, _, _, _, _, _, _, _ ->
-                reportContentHeight(view.measuredHeight / density.toDouble())
+            airshipEmbeddedView.parentHeightProvider = {
+                context.resources.displayMetrics.heightPixels
             }
+            airshipEmbeddedView.addOnLayoutChangeListener(layoutChangeListener)
+
+            val scrollView = ScrollView(context).apply {
+                isVerticalScrollBarEnabled = false
+                layoutParams = FrameLayout.LayoutParams(
+                    FrameLayout.LayoutParams.MATCH_PARENT,
+                    FrameLayout.LayoutParams.MATCH_PARENT
+                )
+            }
+            scrollView.addView(airshipEmbeddedView)
+            root.addView(scrollView)
+        } else {
+            // Percent content must resolve against the box Flutter gives us here.
+            airshipEmbeddedView.parentHeightProvider = null
+            root.addView(airshipEmbeddedView)
         }
+    }
+
+    private fun setSelfSizing(value: Boolean) {
+        if (selfSizing == value) return
+        selfSizing = value
+        // The next report is against a different measurement, so don't suppress it.
+        reportedHeight = -1.0
+        applyContainer()
     }
 
     private fun reportContentHeight(height: Double) {
@@ -74,20 +101,19 @@ class FlutterEmbeddedView(
         channel.invokeMethod("onSizeUpdate", mapOf("height" to height))
     }
 
-    override fun getView(): View {
-        container.layoutParams = FrameLayout.LayoutParams(
-            FrameLayout.LayoutParams.MATCH_PARENT,
-            FrameLayout.LayoutParams.MATCH_PARENT
-        )
-        return container
-    }
+    override fun getView(): View = root
 
     override fun dispose() {
+        airshipEmbeddedView.removeOnLayoutChangeListener(layoutChangeListener)
         channel.setMethodCallHandler(null)
     }
 
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
         when (call.method) {
+            "setSizeToContent" -> {
+                setSelfSizing(call.argument<Boolean>("sizeToContent") ?: false)
+                result.success(null)
+            }
             else -> {
                 result.error("UNAVAILABLE", "Unknown method: ${call.method}", null)
             }
@@ -105,9 +131,9 @@ class EmbeddedViewFactory(
         val params = args as? Map<*, *>
         val embeddedId = params?.get("embeddedId") as? String ?: "defaultId"
         val selection = parseSelection(params?.get("selection") as? Map<*, *>)
-        val parentHeight = (params?.get("parentHeight") as? Number)?.toDouble()
+        val selfSizing = params?.get("sizeToContent") as? Boolean ?: false
 
-        return FlutterEmbeddedView(checkNotNull(context), channel, embeddedId, selection, parentHeight)
+        return FlutterEmbeddedView(checkNotNull(context), channel, embeddedId, selection, selfSizing)
     }
 
     private fun parseSelection(selection: Map<*, *>?): AirshipEmbeddedSelection {

--- a/example/lib/screens/home.dart
+++ b/example/lib/screens/home.dart
@@ -14,7 +14,6 @@ class Home extends StatefulWidget {
 
 class HomeState extends State<Home> {
   static const Uuid _uuid = Uuid();
-  static const double _embeddedViewHeight = 200.0;
   static const String _embeddedViewId = 'home-banner';
 
   bool _isLoading = false;
@@ -255,7 +254,7 @@ class HomeState extends State<Home> {
             borderRadius: BorderRadius.circular(8),
           ),
           child: AirshipEmbeddedView(
-            embeddedId: _embeddedViewId, parentHeight: _embeddedViewHeight,
+            embeddedId: _embeddedViewId,
           ),
         ),
       ],

--- a/example/lib/screens/home.dart
+++ b/example/lib/screens/home.dart
@@ -246,18 +246,8 @@ class HomeState extends State<Home> {
   }
 
   Widget _buildEmbeddedViewSection(ColorScheme colorScheme) {
-    return Column(
-      children: [
-        Container(
-          decoration: BoxDecoration(
-            border: Border.all(color: colorScheme.outline),
-            borderRadius: BorderRadius.circular(8),
-          ),
-          child: AirshipEmbeddedView(
-            embeddedId: _embeddedViewId,
-          ),
-        ),
-      ],
+    return AirshipEmbeddedView(
+      embeddedId: _embeddedViewId,
     );
   }
 

--- a/ios/airship_flutter/Sources/airship_flutter/AirshipEmbeddedView.swift
+++ b/ios/airship_flutter/Sources/airship_flutter/AirshipEmbeddedView.swift
@@ -27,6 +27,10 @@ class AirshipEmbeddedViewFactory: NSObject, FlutterPlatformViewFactory {
 class AirshipEmbeddedViewWrapper: UIView, FlutterPlatformView {
     private static let embeddedIdKey: String = "embeddedId"
 
+    private static func windowHeight() -> CGFloat? {
+        return try? AirshipUtils.mainWindow()?.screen.bounds.height
+    }
+
     private static func parseSelection(_ dict: [String: Any]?) -> AirshipEmbeddedSelection {
         if dict?["type"] as? String == "instance_id",
            let instanceId = dict?["instanceId"] as? String,
@@ -36,43 +40,49 @@ class AirshipEmbeddedViewWrapper: UIView, FlutterPlatformView {
         return .priority
     }
 
-    var viewModel = FlutterAirshipEmbeddedView.ViewModel()
+    private let viewModel = FlutterAirshipEmbeddedView.ViewModel()
+    private let viewController: UIViewController
+    private let channel: FlutterMethodChannel
 
-    public var viewController: UIViewController
-    
-    public var isAdded: Bool = false
-
-    let channel: FlutterMethodChannel
+    private let selfSizing: Bool
+    private var isAdded: Bool = false
+    private var reportedHeight: CGFloat = -1
 
     required init(frame: CGRect, viewId: Int64, registrar: FlutterPluginRegistrar, args: Any?) {
         let channelName = "com.airship.flutter/EmbeddedView_\(viewId)"
         self.channel = FlutterMethodChannel(name: channelName, binaryMessenger: registrar.messenger())
 
-        self.viewController = UIHostingController(
+        let params = args as? [String: Any]
+        let parentHeight = (params?["parentHeight"] as? NSNumber).map { CGFloat($0.doubleValue) }
+        self.selfSizing = parentHeight == nil
+
+        let hostingController = UIHostingController(
             rootView: FlutterAirshipEmbeddedView(viewModel: self.viewModel)
         )
+        hostingController.view.backgroundColor = .clear
+        self.viewController = hostingController
 
-        self.viewController.view.backgroundColor = UIColor.purple
-
-        let rootView = FlutterAirshipEmbeddedView(viewModel: self.viewModel)
-        self.viewController = UIHostingController(
-            rootView: rootView
-        )
-
-        super.init(frame:frame)
+        super.init(frame: frame)
 
         self.translatesAutoresizingMaskIntoConstraints = false
-        self.addSubview(self.viewController.view)
-        self.viewController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        self.addSubview(hostingController.view)
+        hostingController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
 
-        if let params = args as? [String: Any] {
+        if let params {
             if let embeddedId = params[Self.embeddedIdKey] as? String {
-                rootView.viewModel.embeddedID = embeddedId
+                viewModel.embeddedID = embeddedId
             }
-            rootView.viewModel.selection = Self.parseSelection(params["selection"] as? [String: Any])
+            viewModel.selection = Self.parseSelection(params["selection"] as? [String: Any])
         }
+        viewModel.parentWidth = frame.size.width
+        // Percent sized content has no parent height to resolve against, so use the window.
+        viewModel.parentHeight = parentHeight ?? Self.windowHeight()
 
-        rootView.viewModel.size = frame.size
+        if selfSizing {
+            viewModel.onHeightChange = { [weak self] height in
+                self?.reportContentHeight(height)
+            }
+        }
 
         channel.setMethodCallHandler { [weak self] (call: FlutterMethodCall, result: @escaping FlutterResult) in
             self?.handle(call, result: result)
@@ -83,15 +93,6 @@ class AirshipEmbeddedViewWrapper: UIView, FlutterPlatformView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-        switch call.method {
-        default:
-            result(FlutterError(code: "UNAVAILABLE",
-                                message: "Unknown method: \(call.method)",
-                                details: nil))
-        }
-    }
-
     func view() -> UIView {
         return self
     }
@@ -99,16 +100,32 @@ class AirshipEmbeddedViewWrapper: UIView, FlutterPlatformView {
     public override func didMoveToWindow() {
         super.didMoveToWindow()
         guard !self.isAdded else { return }
-        self.viewController.willMove(toParent: self.parentViewController())
-        self.parentViewController().addChild(self.viewController)
-        self.viewController.didMove(toParent: self.parentViewController())
+
+        let parent = self.parentViewController()
+        self.viewController.willMove(toParent: parent)
+        parent.addChild(self.viewController)
+        self.viewController.didMove(toParent: parent)
         self.viewController.view.isUserInteractionEnabled = true
-        isAdded = true
+        self.isAdded = true
     }
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        self.viewModel.size = bounds.size
+        if self.viewModel.parentWidth != bounds.size.width {
+            self.viewModel.parentWidth = bounds.size.width
+        }
+    }
+
+    private func reportContentHeight(_ height: CGFloat) {
+        guard height >= 0, abs(height - self.reportedHeight) > 0.5 else { return }
+        self.reportedHeight = height
+        self.channel.invokeMethod("onSizeUpdate", arguments: ["height": height])
+    }
+
+    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        result(FlutterError(code: "UNAVAILABLE",
+                            message: "Unknown method: \(call.method)",
+                            details: nil))
     }
 }
 
@@ -124,11 +141,26 @@ struct FlutterAirshipEmbeddedView: View {
         if let embeddedID = viewModel.embeddedID {
             AirshipEmbeddedView(embeddedID: embeddedID,
                                 embeddedSize: .init(
-                                    parentWidth: viewModel.size?.width,
-                                    parentHeight: viewModel.size?.height
+                                    parentWidth: viewModel.parentWidth,
+                                    parentHeight: viewModel.parentHeight
                                 ),
                                 selection: viewModel.selection
             )
+            // Report the content's laid-out height so Flutter can size to it.
+            .background(
+                GeometryReader { proxy in
+                    Color.clear.preference(
+                        key: ContentHeightPreferenceKey.self,
+                        value: proxy.size.height
+                    )
+                }
+            )
+            .onPreferenceChange(ContentHeightPreferenceKey.self) { [viewModel] height in
+                // The action is @Sendable, so hop to the main actor for the view model.
+                Task { @MainActor in
+                    viewModel.onHeightChange?(height)
+                }
+            }
         } else {
             Text("Please set embeddedId")
         }
@@ -137,22 +169,19 @@ struct FlutterAirshipEmbeddedView: View {
     @MainActor
     class ViewModel: ObservableObject {
         @Published var embeddedID: String?
-        @Published var size: CGSize?
+        @Published var parentWidth: CGFloat?
+        @Published var parentHeight: CGFloat?
         @Published var selection: AirshipEmbeddedSelection = .priority
 
-        var height: CGFloat {
-            guard let height = self.size?.height, height > 0 else {
-                return try! AirshipUtils.mainWindow()?.screen.bounds.height ?? 500
-            }
-            return height
-        }
+        var onHeightChange: ((CGFloat) -> Void)?
+    }
+}
 
-        var width: CGFloat {
-            guard let width = self.size?.width, width > 0 else {
-                return try! AirshipUtils.mainWindow()?.screen.bounds.width ?? 500
-            }
-            return width
-        }
+private struct ContentHeightPreferenceKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
     }
 }
 

--- a/ios/airship_flutter/Sources/airship_flutter/AirshipEmbeddedView.swift
+++ b/ios/airship_flutter/Sources/airship_flutter/AirshipEmbeddedView.swift
@@ -44,7 +44,7 @@ class AirshipEmbeddedViewWrapper: UIView, FlutterPlatformView {
     private let viewController: UIViewController
     private let channel: FlutterMethodChannel
 
-    private let selfSizing: Bool
+    private var selfSizing: Bool
     private var isAdded: Bool = false
     private var reportedHeight: CGFloat = -1
 
@@ -53,8 +53,8 @@ class AirshipEmbeddedViewWrapper: UIView, FlutterPlatformView {
         self.channel = FlutterMethodChannel(name: channelName, binaryMessenger: registrar.messenger())
 
         let params = args as? [String: Any]
-        let parentHeight = (params?["parentHeight"] as? NSNumber).map { CGFloat($0.doubleValue) }
-        self.selfSizing = parentHeight == nil
+        let selfSizing = (params?["sizeToContent"] as? Bool) ?? false
+        self.selfSizing = selfSizing
 
         let hostingController = UIHostingController(
             rootView: FlutterAirshipEmbeddedView(viewModel: self.viewModel)
@@ -66,7 +66,11 @@ class AirshipEmbeddedViewWrapper: UIView, FlutterPlatformView {
 
         self.translatesAutoresizingMaskIntoConstraints = false
         self.addSubview(hostingController.view)
-        hostingController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        // The host is framed in layoutSubviews: while self sizing it is deliberately
+        // taller than this view, so content measures against a stable proposal
+        // instead of the box Flutter set, which would feed back into measurement.
+        hostingController.view.autoresizingMask = []
+        self.clipsToBounds = true
 
         if let params {
             if let embeddedId = params[Self.embeddedIdKey] as? String {
@@ -75,13 +79,13 @@ class AirshipEmbeddedViewWrapper: UIView, FlutterPlatformView {
             viewModel.selection = Self.parseSelection(params["selection"] as? [String: Any])
         }
         viewModel.parentWidth = frame.size.width
-        // Percent sized content has no parent height to resolve against, so use the window.
-        viewModel.parentHeight = parentHeight ?? Self.windowHeight()
+        viewModel.selfSizing = selfSizing
+        // While self sizing there is no imposed height for percent sized content to
+        // resolve against, so fall back to the window.
+        viewModel.parentHeight = selfSizing ? Self.windowHeight() : frame.size.height
 
-        if selfSizing {
-            viewModel.onHeightChange = { [weak self] height in
-                self?.reportContentHeight(height)
-            }
+        viewModel.onHeightChange = { [weak self] height in
+            self?.reportContentHeight(height)
         }
 
         channel.setMethodCallHandler { [weak self] (call: FlutterMethodCall, result: @escaping FlutterResult) in
@@ -111,8 +115,22 @@ class AirshipEmbeddedViewWrapper: UIView, FlutterPlatformView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
+
+        // Stable measurement proposal: window height while self sizing, so the
+        // measured height cannot depend on the box Flutter just set.
+        let hostHeight = self.selfSizing
+            ? max(Self.windowHeight() ?? bounds.size.height, bounds.size.height)
+            : bounds.size.height
+        let hostFrame = CGRect(x: 0, y: 0, width: bounds.size.width, height: hostHeight)
+        if self.viewController.view.frame != hostFrame {
+            self.viewController.view.frame = hostFrame
+        }
+
         if self.viewModel.parentWidth != bounds.size.width {
             self.viewModel.parentWidth = bounds.size.width
+        }
+        if !self.selfSizing, self.viewModel.parentHeight != bounds.size.height {
+            self.viewModel.parentHeight = bounds.size.height
         }
     }
 
@@ -122,10 +140,27 @@ class AirshipEmbeddedViewWrapper: UIView, FlutterPlatformView {
         self.channel.invokeMethod("onSizeUpdate", arguments: ["height": height])
     }
 
+    private func setSelfSizing(_ value: Bool) {
+        guard self.selfSizing != value else { return }
+        self.selfSizing = value
+        // The next report is against a different measurement, so don't suppress it.
+        self.reportedHeight = -1
+        self.viewModel.selfSizing = value
+        self.viewModel.parentHeight = value ? Self.windowHeight() : bounds.size.height
+        self.setNeedsLayout()
+    }
+
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-        result(FlutterError(code: "UNAVAILABLE",
-                            message: "Unknown method: \(call.method)",
-                            details: nil))
+        switch call.method {
+        case "setSizeToContent":
+            let args = call.arguments as? [String: Any]
+            setSelfSizing((args?["sizeToContent"] as? Bool) ?? false)
+            result(nil)
+        default:
+            result(FlutterError(code: "UNAVAILABLE",
+                                message: "Unknown method: \(call.method)",
+                                details: nil))
+        }
     }
 }
 
@@ -146,21 +181,25 @@ struct FlutterAirshipEmbeddedView: View {
                                 ),
                                 selection: viewModel.selection
             )
-            // Report the content's laid-out height so Flutter can size to it.
+            // Report the height every layout pass, like the SDK's airshipMeasureView;
+            // preference diffing missed the placeholder-to-content transition.
+            // The wrapper dedupes before touching the channel.
             .background(
-                GeometryReader { proxy in
-                    Color.clear.preference(
-                        key: ContentHeightPreferenceKey.self,
-                        value: proxy.size.height
-                    )
+                GeometryReader { [viewModel] proxy -> Color in
+                    let height = proxy.size.height
+                    DispatchQueue.main.async {
+                        viewModel.onHeightChange?(height)
+                    }
+                    return Color.clear
                 }
             )
-            .onPreferenceChange(ContentHeightPreferenceKey.self) { [viewModel] height in
-                // The action is @Sendable, so hop to the main actor for the view model.
-                Task { @MainActor in
-                    viewModel.onHeightChange?(height)
-                }
-            }
+            // While self sizing the host is taller than the visible box, so pin the
+            // content to the top rather than letting SwiftUI center it out of view.
+            .frame(
+                maxWidth: .infinity,
+                maxHeight: .infinity,
+                alignment: viewModel.selfSizing ? .top : .center
+            )
         } else {
             Text("Please set embeddedId")
         }
@@ -171,17 +210,10 @@ struct FlutterAirshipEmbeddedView: View {
         @Published var embeddedID: String?
         @Published var parentWidth: CGFloat?
         @Published var parentHeight: CGFloat?
+        @Published var selfSizing: Bool = false
         @Published var selection: AirshipEmbeddedSelection = .priority
 
         var onHeightChange: ((CGFloat) -> Void)?
-    }
-}
-
-private struct ContentHeightPreferenceKey: PreferenceKey {
-    static let defaultValue: CGFloat = 0
-
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = nextValue()
     }
 }
 

--- a/lib/src/airship_embedded_view.dart
+++ b/lib/src/airship_embedded_view.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
@@ -37,19 +36,17 @@ class AirshipEmbeddedViewSelectionInstanceId extends AirshipEmbeddedViewSelectio
       };
 }
 
-/// Embedded platform view.
-///
-/// When [parentHeight] is omitted, the native side measures the embedded
-/// content and reports its height back, and the widget sizes to match.
+/// Embedded platform view. Sizes from its parent's constraints; when the height
+/// is unbounded, the native side measures the auto-height scene content and the
+/// view adopts it. Scenes that cannot measure fill the space they are given.
 class AirshipEmbeddedView extends StatefulWidget {
   /// The embedded view Id.
   final String embeddedId;
 
-  /// Optional parent width. If not provided, the widget will use available width.
+  /// Optional fixed width. Prefer sizing with the parent, e.g. a [SizedBox].
   final double? parentWidth;
 
-  /// Optional fixed height. If not provided, the view sizes to its content.
-  /// Percent-sized content resolves against this height when set.
+  /// Optional fixed height. Prefer sizing with the parent, e.g. a [SizedBox].
   final double? parentHeight;
 
   /// How to select which pending content to display when more than one is
@@ -81,6 +78,25 @@ class AirshipEmbeddedViewState extends State<AirshipEmbeddedView>
   // Content height reported by the native side. Null until the first report.
   double? _contentHeight;
 
+  // The sizing mode the native view is in. Null until the first layout decides
+  // the mode to create it with.
+  bool? _nativeSelfSizing;
+
+  /// The view measures its own content only when nothing else determines its
+  /// height: no explicit [AirshipEmbeddedView.parentHeight], and a parent that
+  /// leaves the height unbounded.
+  @visibleForTesting
+  static bool isSelfSizing({
+    required BoxConstraints constraints,
+    double? parentHeight,
+  }) =>
+      parentHeight == null && !constraints.hasBoundedHeight;
+
+  bool _isSelfSizing(BoxConstraints constraints) => isSelfSizing(
+        constraints: constraints,
+        parentHeight: widget.parentHeight,
+      );
+
   @override
   void initState() {
     super.initState();
@@ -94,7 +110,11 @@ class AirshipEmbeddedViewState extends State<AirshipEmbeddedView>
         Airship.inApp.isEmbeddedAvailableStream(embeddedId: widget.embeddedId);
     _readySubscription = _readyStream.listen((v) {
       if (mounted && v != _isEmbeddedAvailable) {
-        setState(() => _isEmbeddedAvailable = v);
+        setState(() {
+          _isEmbeddedAvailable = v;
+          // Old content's height must not size whatever arrives next.
+          if (!v) _contentHeight = null;
+        });
       }
     });
   }
@@ -104,8 +124,12 @@ class AirshipEmbeddedViewState extends State<AirshipEmbeddedView>
       case 'onSizeUpdate':
         final args = (call.arguments as Map?)?.cast<String, dynamic>();
         final height = (args?['height'] as num?)?.toDouble();
-        // Only self-size when the caller hasn't pinned an explicit height.
-        if (height != null && mounted && widget.parentHeight == null) {
+        // Degenerate reports happen transiently during dismissal; hold the last
+        // real height and let the availability check collapse the view instead.
+        if (height != null &&
+            height > _minContentHeight &&
+            mounted &&
+            height != _contentHeight) {
           setState(() => _contentHeight = height);
         }
         break;
@@ -116,20 +140,95 @@ class AirshipEmbeddedViewState extends State<AirshipEmbeddedView>
 
   void _onPlatformViewCreated(int id) {
     _channel?.setMethodCallHandler(null);
-    _channel = MethodChannel('com.airship.flutter/EmbeddedView_$id')
+    final channel = MethodChannel('com.airship.flutter/EmbeddedView_$id')
       ..setMethodCallHandler(_methodCallHandler);
+    _channel = channel;
+
+    // The mode may have changed between the layout that supplied the creation
+    // params and the view actually being created, so restate it.
+    final selfSizing = _nativeSelfSizing;
+    if (selfSizing != null) {
+      channel
+          .invokeMethod('setSizeToContent', {'sizeToContent': selfSizing})
+          .catchError((Object _) => null);
+    }
   }
 
-  Widget buildReadyView(
-      BuildContext context, Widget view, BoxConstraints constraints) {
-    final width = widget.parentWidth ??
-        (constraints.maxWidth.isFinite
-            ? constraints.maxWidth
-            : MediaQuery.of(context).size.width);
+  /// Keeps the native sizing mode in step with the constraints, so a parent that
+  /// changes between bounding and not bounding the height is followed.
+  void _syncSelfSizing(bool selfSizing) {
+    if (_nativeSelfSizing == selfSizing) {
+      return;
+    }
+    final isFirstLayout = _nativeSelfSizing == null;
+    _nativeSelfSizing = selfSizing;
 
-    // Never zero: platform views can't be created or resized to an empty size.
-    final height = max(1.0, widget.parentHeight ?? _contentHeight ?? 1.0);
+    // The first value is carried by the creation params instead.
+    if (isFirstLayout) {
+      return;
+    }
 
+    final channel = _channel;
+    if (channel == null) {
+      return;
+    }
+    // Runs during layout, so defer out of the frame; by then the view may be
+    // gone or replaced, so bail out rather than poke a dead channel.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !identical(_channel, channel)) return;
+      channel
+          .invokeMethod('setSizeToContent', {'sizeToContent': selfSizing})
+          .catchError((Object _) => null);
+    });
+  }
+
+  /// Heights at or below this are treated as the native side failing to resolve
+  /// one, rather than as a real content height.
+  static const double _minContentHeight = 1.0;
+
+  /// Resolves the platform view's size from the parent's constraints and, when
+  /// self sizing, the last reported content height. The fallbacks apply while a
+  /// dimension is unbounded and unmeasured.
+  @visibleForTesting
+  static Size resolveSize({
+    required BoxConstraints constraints,
+    required double fallbackWidth,
+    required double fallbackHeight,
+    double? parentWidth,
+    double? parentHeight,
+    double? contentHeight,
+  }) {
+    final width = parentWidth ??
+        (constraints.hasBoundedWidth ? constraints.maxWidth : fallbackWidth);
+
+    // A report at or below the floor means "could not resolve", not "empty";
+    // gone content is handled by the availability check, so stay visible.
+    final measured = (contentHeight != null && contentHeight > _minContentHeight)
+        ? contentHeight
+        : null;
+
+    // Until a usable measurement arrives, take the available space so native has
+    // room to lay out; whatever the view does not need is returned on report.
+    final height = parentHeight ??
+        (constraints.hasBoundedHeight
+            ? constraints.maxHeight
+            : (measured ?? fallbackHeight));
+
+    return Size(width, height);
+  }
+
+  Size _resolveSize(BuildContext context, BoxConstraints constraints) {
+    return resolveSize(
+      constraints: constraints,
+      fallbackWidth: MediaQuery.of(context).size.width,
+      fallbackHeight: MediaQuery.of(context).size.height,
+      parentWidth: widget.parentWidth,
+      parentHeight: widget.parentHeight,
+      contentHeight: _contentHeight,
+    );
+  }
+
+  Widget buildReadyView(BuildContext context, Widget view, Size availableSize) {
     return AnimatedSwitcher(
       duration: const Duration(milliseconds: 200),
       transitionBuilder: (Widget child, Animation<double> animation) {
@@ -138,8 +237,8 @@ class AirshipEmbeddedViewState extends State<AirshipEmbeddedView>
       child: _isEmbeddedAvailable == true
           ? SizedBox(
               key: ValueKey<bool>(true),
-              width: width,
-              height: height,
+              width: widget.parentWidth ?? availableSize.width,
+              height: widget.parentHeight ?? availableSize.height,
               child: view,
             )
           : SizedBox(key: ValueKey<bool>(false), height: 0),
@@ -147,9 +246,20 @@ class AirshipEmbeddedViewState extends State<AirshipEmbeddedView>
   }
 
   Widget wrapWithLayoutBuilder(Widget view) {
+    return _wrapWithLayoutBuilder((_) => view);
+  }
+
+  /// The platform view has to be created knowing whether it should measure its
+  /// own content, so it is built inside the layout pass that resolves that.
+  Widget _wrapWithLayoutBuilder(Widget Function(bool selfSizing) viewBuilder) {
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
-        return Center(child: buildReadyView(context, view, constraints));
+        final selfSizing = _isSelfSizing(constraints);
+        _syncSelfSizing(selfSizing);
+        final view = viewBuilder(selfSizing);
+        final size = _resolveSize(context, constraints);
+
+        return Center(child: buildReadyView(context, view, size));
       },
     );
   }
@@ -159,28 +269,34 @@ class AirshipEmbeddedViewState extends State<AirshipEmbeddedView>
     super.build(context);
 
     if (defaultTargetPlatform == TargetPlatform.android) {
-      return _getAndroidView();
+      return _wrapWithLayoutBuilder(_getAndroidView);
     } else if (defaultTargetPlatform == TargetPlatform.iOS) {
-      return wrapWithLayoutBuilder(
-        UiKitView(
-          viewType: 'com.airship.flutter/EmbeddedView',
-          onPlatformViewCreated: _onPlatformViewCreated,
-          creationParams: <String, Object?>{
-            'embeddedId': widget.embeddedId,
-            'selection': widget.selection?.toJson(),
-            'parentHeight': widget.parentHeight,
-          },
-          creationParamsCodec: const StandardMessageCodec(),
-        ),
-      );
+      return _wrapWithLayoutBuilder(_getIOSView);
     }
 
     return Text('$defaultTargetPlatform is not yet supported by this plugin');
   }
 
-  Widget _getAndroidView() {
+  Map<String, Object?> _creationParams(bool selfSizing) {
+    return <String, Object?>{
+      'embeddedId': widget.embeddedId,
+      'selection': widget.selection?.toJson(),
+      'sizeToContent': selfSizing,
+    };
+  }
+
+  Widget _getIOSView(bool selfSizing) {
+    return UiKitView(
+      viewType: 'com.airship.flutter/EmbeddedView',
+      onPlatformViewCreated: _onPlatformViewCreated,
+      creationParams: _creationParams(selfSizing),
+      creationParamsCodec: const StandardMessageCodec(),
+    );
+  }
+
+  Widget _getAndroidView(bool selfSizing) {
     if (AirshipEmbeddedView.hybridComposition) {
-      return wrapWithLayoutBuilder(PlatformViewLink(
+      return PlatformViewLink(
         viewType: 'com.airship.flutter/EmbeddedView',
         surfaceFactory:
             (BuildContext context, PlatformViewController controller) {
@@ -195,11 +311,7 @@ class AirshipEmbeddedViewState extends State<AirshipEmbeddedView>
             id: params.id,
             viewType: 'com.airship.flutter/EmbeddedView',
             layoutDirection: TextDirection.ltr,
-            creationParams: <String, Object?>{
-              'embeddedId': widget.embeddedId,
-              'selection': widget.selection?.toJson(),
-              'parentHeight': widget.parentHeight,
-            },
+            creationParams: _creationParams(selfSizing),
             creationParamsCodec: const StandardMessageCodec(),
             onFocus: () {
               params.onFocusChanged(true);
@@ -209,18 +321,14 @@ class AirshipEmbeddedViewState extends State<AirshipEmbeddedView>
             ..addOnPlatformViewCreatedListener(_onPlatformViewCreated)
             ..create();
         },
-      ));
+      );
     } else {
-      return wrapWithLayoutBuilder(AndroidView(
+      return AndroidView(
         viewType: 'com.airship.flutter/EmbeddedView',
         onPlatformViewCreated: _onPlatformViewCreated,
-        creationParams: <String, Object?>{
-          'embeddedId': widget.embeddedId,
-          'selection': widget.selection?.toJson(),
-          'parentHeight': widget.parentHeight,
-        },
+        creationParams: _creationParams(selfSizing),
         creationParamsCodec: const StandardMessageCodec(),
-      ));
+      );
     }
   }
 

--- a/lib/src/airship_embedded_view.dart
+++ b/lib/src/airship_embedded_view.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
@@ -38,9 +39,8 @@ class AirshipEmbeddedViewSelectionInstanceId extends AirshipEmbeddedViewSelectio
 
 /// Embedded platform view.
 ///
-/// Note: When an embedded view is set to display with its height set to `auto`
-/// the embedded view will size to its native aspect ratio. Any remaining space
-/// in the parent view will be apparent.
+/// When [parentHeight] is omitted, the native side measures the embedded
+/// content and reports its height back, and the widget sizes to match.
 class AirshipEmbeddedView extends StatefulWidget {
   /// The embedded view Id.
   final String embeddedId;
@@ -48,9 +48,8 @@ class AirshipEmbeddedView extends StatefulWidget {
   /// Optional parent width. If not provided, the widget will use available width.
   final double? parentWidth;
 
-  /// Optional parent height. If not provided, the widget will use available height.
-  /// Use parentHeight for constant height instead of a height-constrained container.
-  /// This allows proper collapse to 0 height when the view is dismissed.
+  /// Optional fixed height. If not provided, the view sizes to its content.
+  /// Percent-sized content resolves against this height when set.
   final double? parentHeight;
 
   /// How to select which pending content to display when more than one is
@@ -73,11 +72,14 @@ class AirshipEmbeddedView extends StatefulWidget {
 
 class AirshipEmbeddedViewState extends State<AirshipEmbeddedView>
     with AutomaticKeepAliveClientMixin<AirshipEmbeddedView> {
-  late MethodChannel _channel;
+  MethodChannel? _channel;
   late Stream<bool> _readyStream;
   late final StreamSubscription<bool> _readySubscription;
 
   bool? _isEmbeddedAvailable;
+
+  // Content height reported by the native side. Null until the first report.
+  double? _contentHeight;
 
   @override
   void initState() {
@@ -99,17 +101,35 @@ class AirshipEmbeddedViewState extends State<AirshipEmbeddedView>
 
   Future<void> _methodCallHandler(MethodCall call) async {
     switch (call.method) {
+      case 'onSizeUpdate':
+        final args = (call.arguments as Map?)?.cast<String, dynamic>();
+        final height = (args?['height'] as num?)?.toDouble();
+        // Only self-size when the caller hasn't pinned an explicit height.
+        if (height != null && mounted && widget.parentHeight == null) {
+          setState(() => _contentHeight = height);
+        }
+        break;
       default:
         print('Unknown method.');
     }
   }
 
-  Future<void> _onPlatformViewCreated(int id) async {
-    _channel = MethodChannel('com.airship.flutter/EmbeddedView_$id');
-    _channel.setMethodCallHandler(_methodCallHandler);
+  void _onPlatformViewCreated(int id) {
+    _channel?.setMethodCallHandler(null);
+    _channel = MethodChannel('com.airship.flutter/EmbeddedView_$id')
+      ..setMethodCallHandler(_methodCallHandler);
   }
 
-  Widget buildReadyView(BuildContext context, Widget view, Size availableSize) {
+  Widget buildReadyView(
+      BuildContext context, Widget view, BoxConstraints constraints) {
+    final width = widget.parentWidth ??
+        (constraints.maxWidth.isFinite
+            ? constraints.maxWidth
+            : MediaQuery.of(context).size.width);
+
+    // Never zero: platform views can't be created or resized to an empty size.
+    final height = max(1.0, widget.parentHeight ?? _contentHeight ?? 1.0);
+
     return AnimatedSwitcher(
       duration: const Duration(milliseconds: 200),
       transitionBuilder: (Widget child, Animation<double> animation) {
@@ -118,8 +138,8 @@ class AirshipEmbeddedViewState extends State<AirshipEmbeddedView>
       child: _isEmbeddedAvailable == true
           ? SizedBox(
               key: ValueKey<bool>(true),
-              width: widget.parentWidth ?? availableSize.width,
-              height: widget.parentHeight ?? availableSize.height,
+              width: width,
+              height: height,
               child: view,
             )
           : SizedBox(key: ValueKey<bool>(false), height: 0),
@@ -129,9 +149,7 @@ class AirshipEmbeddedViewState extends State<AirshipEmbeddedView>
   Widget wrapWithLayoutBuilder(Widget view) {
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
-        final availableSize = MediaQuery.of(context).size;
-
-        return Center(child: buildReadyView(context, view, availableSize));
+        return Center(child: buildReadyView(context, view, constraints));
       },
     );
   }
@@ -150,6 +168,7 @@ class AirshipEmbeddedViewState extends State<AirshipEmbeddedView>
           creationParams: <String, Object?>{
             'embeddedId': widget.embeddedId,
             'selection': widget.selection?.toJson(),
+            'parentHeight': widget.parentHeight,
           },
           creationParamsCodec: const StandardMessageCodec(),
         ),
@@ -179,6 +198,7 @@ class AirshipEmbeddedViewState extends State<AirshipEmbeddedView>
             creationParams: <String, Object?>{
               'embeddedId': widget.embeddedId,
               'selection': widget.selection?.toJson(),
+              'parentHeight': widget.parentHeight,
             },
             creationParamsCodec: const StandardMessageCodec(),
             onFocus: () {
@@ -186,6 +206,7 @@ class AirshipEmbeddedViewState extends State<AirshipEmbeddedView>
             },
           )
             ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
+            ..addOnPlatformViewCreatedListener(_onPlatformViewCreated)
             ..create();
         },
       ));
@@ -196,6 +217,7 @@ class AirshipEmbeddedViewState extends State<AirshipEmbeddedView>
         creationParams: <String, Object?>{
           'embeddedId': widget.embeddedId,
           'selection': widget.selection?.toJson(),
+          'parentHeight': widget.parentHeight,
         },
         creationParamsCodec: const StandardMessageCodec(),
       ));
@@ -205,7 +227,7 @@ class AirshipEmbeddedViewState extends State<AirshipEmbeddedView>
   @override
   void dispose() {
     _readySubscription.cancel();
-    _channel.setMethodCallHandler(null);
+    _channel?.setMethodCallHandler(null);
     super.dispose();
   }
 

--- a/lib/src/airship_events.dart
+++ b/lib/src/airship_events.dart
@@ -89,9 +89,11 @@ class EmbeddedInfoUpdatedEvent {
 
     List<EmbeddedInfo> embeddedInfos = pendingList
         .map((item) => EmbeddedInfo(
-              item['embeddedId'],
-              item['instanceId'],
-              item['priority'],
+              item['embeddedId'] as String,
+              item['instanceId'] as String,
+              // Crosses the platform channel as a double, so widen before
+              // narrowing rather than casting straight to int.
+              (item['priority'] as num?)?.toInt() ?? 0,
               Map<String, dynamic>.from(item['extras'] ?? {}),
             ))
         .toList();

--- a/lib/src/airship_in_app.dart
+++ b/lib/src/airship_in_app.dart
@@ -60,6 +60,11 @@ class AirshipInApp {
             controller.add(isAvailable);
           }
         });
+
+        // Ask the native side to replay the current embedded state. Without this a
+        // view that subscribes after the last update never learns about content
+        // that already exists, because the cached list is only filled by events.
+        _resendLastEmbeddedEvent();
       },
       onCancel: () {
         subscription?.cancel();


### PR DESCRIPTION
### What do these changes do?
Embedded views size to their content when the parent leaves the height unbounded. The native side measures the scene against a stable proposal (a scroll view on Android, a window-height host on iOS), reports the height over the platform channel, and the widget adopts it. Bounded layouts keep the existing fill behavior, so current integrations are unaffected; parentHeight and parentWidth still work as explicit overrides. The sizing mode follows layout constraints and can change at runtime.

Also fixes two pre-existing bugs this feature surfaced:
- Embedded availability was permanently false: priority arrives on the platform channel as a double and the parser cast it to int, so every embedded info update threw and the error was swallowed.
- Views subscribing after the last update never learned about existing content. Pending state now replays on each availability stream subscribe.

### Why are these changes necessary?
Only the native layout engine knows a scene's rendered height, so any hardcoded height is a guess that leaves a gap or clips on some device or content combination. Deriving the mode from constraints instead of from an omitted parentHeight keeps the API non-breaking and matches how Flutter widgets normally size.

Note: sizing to content requires the scene to be auto height under its placement. Scenes that resolve height against their parent (percent chains) fill the available space instead of collapsing. Related Android SDK fix for percent widths inside horizontal scroll layouts: urbanairship/android-library-dev#2127

### How did you verify these changes?
Manually in simulators against composer-built scenes: iPhone and iPad (stable content sizing, correct rendering, including a scene that previously oscillated between two heights on iPad), and an API 35 Android emulator (content sizing tracking scene changes, clean collapse on dismiss). flutter analyze, dart analyze --fatal-infos, flutter test, and release builds on both platforms pass against proxy 15.13.0.
