### PR TITLE
Bump Android compileSdk to 36

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,7 +36,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdk 35
+    compileSdk 36
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-     id "com.android.application" version '8.9.1' apply false
+     id "com.android.application" version '8.13.0' apply false
      id "org.jetbrains.kotlin.android" version "2.1.20" apply false
      id "com.google.gms.google-services" version "4.3.14" apply false
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Jul 03 16:09:47 PDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '8.9.1' apply false
+    id "com.android.application" version '8.13.0' apply false
     id "org.jetbrains.kotlin.android" version "2.1.20" apply false
 }
 


### PR DESCRIPTION

- `android/build.gradle`: `compileSdk 35` → `36`
- `example/android`: AGP `8.9.1` → `8.13.0`, Gradle wrapper `8.11.1` → `8.13`

The plugin's bundled deps (`urbanairship-*:20.10.0`, `androidx.core:1.17.0`,
`androidx.activity:1.11.0`) declare `minCompileSdk=36`, but the plugin was
pinned to `compileSdk 35`. On AGP ≥ 8.13 (which adds per-library AAR-metadata
checks) this fails `:airship_flutter:checkReleaseAarMetadata` with 14
violations, blocking any consuming app's Android build.

Bumping `compileSdk` to 36 only changes the compile-time API level
(`targetSdk` unchanged → no runtime behavior change) and aligns the module
with requirements its own dependencies already impose.

The example/CI toolchain bump to AGP 8.13 is included so CI actually exercises
the per-library check and catches this class of regression (AGP 8.9.1 did not).