### PR TITLE
Add missing iOS native bindings and align feature flag API with react-native

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,56 @@
 # Migration Guide
 
+# 12.5.x to 12.6.0
+
+## Feature Flags
+
+### `flag()` now throws instead of returning null
+
+`Airship.featureFlagManager.flag()` used to catch every error, log it, and
+return `null`. It now returns a non-null `FeatureFlag` and throws a
+`PlatformException` when the flag cannot be resolved, matching the React Native
+plugin and the native SDKs. Errors that were previously silent - including a
+flag that failed to download or Airship not being ready - now surface to the
+caller.
+
+#### Before (12.5.x)
+
+```dart
+final flag = await Airship.featureFlagManager.flag("my_flag");
+if (flag == null) {
+  // Could be an error, no way to tell
+  return;
+}
+Airship.featureFlagManager.trackInteraction(flag);
+```
+
+#### After (12.6.0)
+
+```dart
+try {
+  final flag = await Airship.featureFlagManager.flag("my_flag");
+  Airship.featureFlagManager.trackInteraction(flag);
+} on PlatformException catch (e) {
+  // Handle the failure
+  debugPrint("Failed to fetch flag: $e");
+}
+```
+
+### `useResultCache` now defaults to true
+
+The `useResultCache` argument on `flag()` defaults to `true`, matching the
+React Native plugin and the native SDKs. Pass `useResultCache: false` to keep
+the old behavior.
+
+```dart
+// 12.5.x behavior
+final flag = await Airship.featureFlagManager.flag(
+  "my_flag",
+  useResultCache: false,
+);
+```
+
+
 # 10.x to 11.x
 
 ## Min iOS Version

--- a/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
+++ b/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt
@@ -373,13 +373,17 @@ class AirshipPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             "featureFlagManager#flag" -> result.resolve(scope, call) {
                 val args = call.jsonArgs().requireMap()
                 val flagName = requireNotNull(args.get("flagName")?.requireString())
-                val useResultCache = args.get("useResultCache")?.getBoolean(false) ?: false
+                val useResultCache = args.get("useResultCache")?.getBoolean(true) ?: true
                 proxy.featureFlagManager.flag(flagName, useResultCache)
             }
 
             "featureFlagManager#trackInteraction" -> result.resolve(scope, call) {
                 val parsedFlag = FeatureFlagProxy(JsonValue.parseString(call.stringArg()))
                 proxy.featureFlagManager.trackInteraction(parsedFlag)
+            }
+
+            "featureFlagManager#resultCacheGetFlag" -> result.resolve(scope, call) {
+                proxy.featureFlagManager.resultCache.flag(call.stringArg())
             }
 
             "featureFlagManager#resultCacheRemoveFlag" -> result.resolve(scope, call) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -112,9 +112,7 @@ class _MainNavigatorState extends State<MainNavigator> {
 
   static void _trackFeatureFlagInteraction() {
     Airship.featureFlagManager.flag("rad_flag").then((flag) {
-      if (flag != null) {
-        Airship.featureFlagManager.trackInteraction(flag);
-      }
+      Airship.featureFlagManager.trackInteraction(flag);
     }).catchError((e) {
       debugPrint('Error: $e');
     });

--- a/ios/airship_flutter/Sources/airship_flutter/AirshipPlugin.swift
+++ b/ios/airship_flutter/Sources/airship_flutter/AirshipPlugin.swift
@@ -214,6 +214,10 @@ public class AirshipPlugin: NSObject, FlutterPlugin {
         case "channel#getTags":
             return try AirshipProxy.shared.channel.tags
 
+        case "channel#enableChannelCreation":
+            try AirshipProxy.shared.channel.enableChannelCreation()
+            return nil
+
         case "channel#editTagGroups":
             let operation = try JSONDecoder().decode(
                 [TagGroupOperation].self,
@@ -740,6 +744,39 @@ public class AirshipPlugin: NSObject, FlutterPlugin {
 
             try AirshipProxy.shared.featureFlagManager.trackInteraction(flag: featureFlagProxy)
 
+            return nil
+
+        case "featureFlagManager#resultCacheGetFlag":
+            let flag = try await AirshipProxy.shared.featureFlagManager.resultCache.flag(
+                name: try call.requireStringArg()
+            )
+            return try AirshipJSON.wrap(flag).unWrap()
+
+        case "featureFlagManager#resultCacheSetFlag":
+            let args = try call.requireMapArg()
+
+            guard
+                let flagJSON = args["flag"] as? String,
+                let jsonData = flagJSON.data(using: .utf8),
+                let featureFlagProxy = try? JSONDecoder().decode(FeatureFlagProxy.self, from: jsonData)
+            else {
+                throw AirshipErrors.error("Call requires a flag json string that's decodable to FeatureFlagProxy")
+            }
+
+            guard let ttl = args["ttl"] as? NSNumber else {
+                throw AirshipErrors.error("Call requires a ttl in milliseconds")
+            }
+
+            try await AirshipProxy.shared.featureFlagManager.resultCache.cache(
+                flag: featureFlagProxy,
+                ttl: ttl.doubleValue / 1000.0
+            )
+            return nil
+
+        case "featureFlagManager#resultCacheRemoveFlag":
+            try await AirshipProxy.shared.featureFlagManager.resultCache.removeCachedFlag(
+                name: try call.requireStringArg()
+            )
             return nil
 
         default:

--- a/lib/src/airship_feature_flag_manager.dart
+++ b/lib/src/airship_feature_flag_manager.dart
@@ -9,9 +9,13 @@ class AirshipFeatureFlagManager {
   AirshipFeatureFlagManager(AirshipModule module) : _module = module;
 
   /// Gets and evaluates a feature flag with the given [name].
-  /// [useResultCache] determines if the cached result should be used.
-  Future<FeatureFlag?> flag(String name, {bool useResultCache = false}) async {
-  try {
+  ///
+  /// [useResultCache] determines if the result cache should be used when
+  /// evaluating the flag. Defaults to `true`.
+  ///
+  /// Throws a [PlatformException] if the flag fails to resolve, e.g. if the
+  /// flags have not yet been downloaded or Airship is not ready.
+  Future<FeatureFlag> flag(String name, {bool useResultCache = true}) async {
     var featureFlag = await _module.channel.invokeMethod(
       "featureFlagManager#flag",
       {
@@ -19,16 +23,16 @@ class AirshipFeatureFlagManager {
         "useResultCache": useResultCache,
       },
     );
+
+    if (featureFlag == null) {
+      throw PlatformException(
+        code: "AIRSHIP_ERROR",
+        message: "Failed to fetch feature flag: $name",
+        details: "Method: featureFlagManager#flag",
+      );
+    }
+
     return FeatureFlag._fromJson(featureFlag);
-  } on PlatformException catch (e) {
-    // Catches only PlatformException 
-    print("Airship feature flag error: $e");
-    return null;
-  } catch (e) {
-    // Catches any other exception type
-    print("Unexpected error: $e");
-    return null;
-  }
   }
 
   /// Tracks interaction with feature flag
@@ -37,7 +41,8 @@ class AirshipFeatureFlagManager {
         .invokeMethod("featureFlagManager#trackInteraction", flag.toJSON());
   }
 
-  /// Gets a flag from the result cache.
+  /// Gets a flag from the result cache. Returns null if the flag is not
+  /// cached or the cached value has expired.
   Future<FeatureFlag?> getFlagFromResultCache(String flagName) async {
     var featureFlag = await _module.channel.invokeMethod(
       "featureFlagManager#resultCacheGetFlag",
@@ -46,7 +51,7 @@ class AirshipFeatureFlagManager {
     return featureFlag != null ? FeatureFlag._fromJson(featureFlag) : null;
   }
 
-  /// Sets a flag in the result cache.
+  /// Sets a flag in the result cache with the given [ttl].
   Future<void> setFlagInResultCache(FeatureFlag flag, Duration ttl) async {
     await _module.channel.invokeMethod(
       "featureFlagManager#resultCacheSetFlag",

--- a/test/airship_channel_test.dart
+++ b/test/airship_channel_test.dart
@@ -1,0 +1,33 @@
+import 'package:airship_flutter/airship_flutter.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const MethodChannel channel = MethodChannel('com.airship.flutter/airship');
+
+  final List<MethodCall> calls = <MethodCall>[];
+
+  setUp(() {
+    calls.clear();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall call) async {
+      calls.add(call);
+      return null;
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  test('enableChannelCreation sends the method with no arguments', () async {
+    await Airship.channel.enableChannelCreation();
+
+    expect(calls, hasLength(1));
+    expect(calls.first.method, "channel#enableChannelCreation");
+    expect(calls.first.arguments, isNull);
+  });
+}

--- a/test/airship_feature_flag_manager_test.dart
+++ b/test/airship_feature_flag_manager_test.dart
@@ -1,0 +1,172 @@
+import 'dart:convert';
+
+import 'package:airship_flutter/airship_flutter.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const MethodChannel channel = MethodChannel('com.airship.flutter/airship');
+
+  final List<MethodCall> calls = <MethodCall>[];
+
+  /// Mocks the platform side, recording every call and replying with
+  /// [response], or throwing [error] if one is set.
+  void mockChannel({Object? response, PlatformException? error}) {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall call) async {
+      calls.add(call);
+      if (error != null) {
+        throw error;
+      }
+      return response;
+    });
+  }
+
+  final Map<String, Object?> flagJson = {
+    "isEligible": true,
+    "exists": true,
+    "variables": {"foo": "bar"},
+    "_internal": {"name": "rad_flag"},
+  };
+
+  setUp(() {
+    calls.clear();
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  group('flag', () {
+    test('uses the result cache by default', () async {
+      mockChannel(response: flagJson);
+
+      await Airship.featureFlagManager.flag("rad_flag");
+
+      expect(calls, hasLength(1));
+      expect(calls.first.method, "featureFlagManager#flag");
+      expect(calls.first.arguments, {
+        "flagName": "rad_flag",
+        "useResultCache": true,
+      });
+    });
+
+    test('passes useResultCache through', () async {
+      mockChannel(response: flagJson);
+
+      await Airship.featureFlagManager.flag("rad_flag", useResultCache: false);
+
+      expect(calls.first.arguments, {
+        "flagName": "rad_flag",
+        "useResultCache": false,
+      });
+    });
+
+    test('parses the platform response', () async {
+      mockChannel(response: flagJson);
+
+      final flag = await Airship.featureFlagManager.flag("rad_flag");
+
+      expect(flag.isEligible, true);
+      expect(flag.exists, true);
+      expect(flag.variables, {"foo": "bar"});
+      expect(flag.original, {"name": "rad_flag"});
+    });
+
+    test('throws instead of returning null on a platform error', () async {
+      mockChannel(
+        error: PlatformException(code: "AIRSHIP_ERROR", message: "boom"),
+      );
+
+      expect(
+        Airship.featureFlagManager.flag("rad_flag"),
+        throwsA(isA<PlatformException>()),
+      );
+    });
+
+    test('throws when the platform has no implementation', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+
+      expect(
+        Airship.featureFlagManager.flag("rad_flag"),
+        throwsA(isA<MissingPluginException>()),
+      );
+    });
+
+    test('throws when the platform returns nothing', () async {
+      mockChannel(response: null);
+
+      expect(
+        Airship.featureFlagManager.flag("rad_flag"),
+        throwsA(isA<PlatformException>()),
+      );
+    });
+  });
+
+  group('trackInteraction', () {
+    test('sends the flag as a json string', () async {
+      mockChannel(response: flagJson);
+      final flag = await Airship.featureFlagManager.flag("rad_flag");
+      calls.clear();
+
+      await Airship.featureFlagManager.trackInteraction(flag);
+
+      expect(calls, hasLength(1));
+      expect(calls.first.method, "featureFlagManager#trackInteraction");
+      expect(jsonDecode(calls.first.arguments as String), flagJson);
+    });
+  });
+
+  group('result cache', () {
+    test('getFlagFromResultCache sends the flag name', () async {
+      mockChannel(response: flagJson);
+
+      final flag =
+          await Airship.featureFlagManager.getFlagFromResultCache("rad_flag");
+
+      expect(calls, hasLength(1));
+      expect(calls.first.method, "featureFlagManager#resultCacheGetFlag");
+      expect(calls.first.arguments, "rad_flag");
+      expect(flag?.isEligible, true);
+    });
+
+    test('getFlagFromResultCache returns null on a cache miss', () async {
+      mockChannel(response: null);
+
+      final flag =
+          await Airship.featureFlagManager.getFlagFromResultCache("rad_flag");
+
+      expect(calls.first.method, "featureFlagManager#resultCacheGetFlag");
+      expect(flag, isNull);
+    });
+
+    test('setFlagInResultCache sends the flag json and a ttl in ms', () async {
+      mockChannel(response: flagJson);
+      final flag = await Airship.featureFlagManager.flag("rad_flag");
+      calls.clear();
+
+      await Airship.featureFlagManager
+          .setFlagInResultCache(flag, const Duration(seconds: 30));
+
+      expect(calls, hasLength(1));
+      expect(calls.first.method, "featureFlagManager#resultCacheSetFlag");
+      final arguments = calls.first.arguments as Map;
+      expect(arguments["ttl"], 30000);
+      expect(jsonDecode(arguments["flag"] as String), flagJson);
+    });
+
+    test('removeFlagFromResultCache sends the flag name', () async {
+      mockChannel(response: null);
+
+      await Airship.featureFlagManager.removeFlagFromResultCache("rad_flag");
+
+      expect(calls, hasLength(1));
+      expect(calls.first.method, "featureFlagManager#resultCacheRemoveFlag");
+      expect(calls.first.arguments, "rad_flag");
+    });
+  });
+}

--- a/test/native_method_parity_test.dart
+++ b/test/native_method_parity_test.dart
@@ -1,0 +1,134 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Verifies that every method the Dart layer invokes is actually handled by
+/// both native plugins. Dart level tests mock the platform, so they cannot
+/// catch a binding that was never wired up on one platform - this can.
+void main() {
+  final Directory root = _packageRoot();
+
+  final Set<String> dartMethods = _dartMethods(Directory('${root.path}/lib'));
+
+  final Set<String> iosMethods = _nativeMethods(
+    File(
+      '${root.path}/ios/airship_flutter/Sources/airship_flutter/AirshipPlugin.swift',
+    ),
+    RegExp(r'case\s+"([^"]+)"'),
+  );
+
+  final Set<String> androidMethods = _nativeMethods(
+    File(
+      '${root.path}/android/src/main/kotlin/com/airship/flutter/AirshipPlugin.kt',
+    ),
+    RegExp(r'"([^"]+)"\s*->'),
+  );
+
+  // Methods that only exist on one platform. Platform specific APIs are
+  // normally named with an `#ios#` or `#android#` segment, these are the
+  // exceptions.
+  const Set<String> iosOnlyMethods = {
+    "liveActivity#list",
+    "liveActivity#listAll",
+    "liveActivity#start",
+    "liveActivity#stop",
+    "liveActivity#update",
+  };
+  const Set<String> androidOnlyMethods = {};
+
+  test('the Dart layer invokes methods', () {
+    // Guards against the extraction below silently matching nothing.
+    expect(dartMethods.length, greaterThan(50));
+    expect(iosMethods, isNotEmpty);
+    expect(androidMethods, isNotEmpty);
+  });
+
+  test('every Dart method is handled on iOS', () {
+    final missing = dartMethods
+        .where((method) => !method.contains("#android#"))
+        .where((method) => !androidOnlyMethods.contains(method))
+        .where((method) => !iosMethods.contains(method))
+        .toList()
+      ..sort();
+
+    expect(missing, isEmpty, reason: "Missing iOS implementations: $missing");
+  });
+
+  test('every Dart method is handled on Android', () {
+    final missing = dartMethods
+        .where((method) => !method.contains("#ios#"))
+        .where((method) => !iosOnlyMethods.contains(method))
+        .where((method) => !androidMethods.contains(method))
+        .toList()
+      ..sort();
+
+    expect(missing, isEmpty,
+        reason: "Missing Android implementations: $missing");
+  });
+
+  group('feature flag and channel bindings', () {
+    // These four were shipped in Dart without an iOS implementation, and
+    // `resultCacheGetFlag` without an Android one. See MOBILE-5831.
+    const methods = [
+      "channel#enableChannelCreation",
+      "featureFlagManager#resultCacheGetFlag",
+      "featureFlagManager#resultCacheSetFlag",
+      "featureFlagManager#resultCacheRemoveFlag",
+    ];
+
+    for (final method in methods) {
+      test('$method is bound on both platforms', () {
+        expect(dartMethods, contains(method));
+        expect(iosMethods, contains(method));
+        expect(androidMethods, contains(method));
+      });
+    }
+  });
+}
+
+/// Walks up from the current directory to find the plugin root.
+Directory _packageRoot() {
+  Directory directory = Directory.current;
+  while (true) {
+    final pubspec = File('${directory.path}/pubspec.yaml');
+    if (pubspec.existsSync() &&
+        pubspec.readAsStringSync().contains("name: airship_flutter")) {
+      return directory;
+    }
+
+    final parent = directory.parent;
+    if (parent.path == directory.path) {
+      throw StateError(
+        "Unable to find the airship_flutter package root from ${Directory.current.path}",
+      );
+    }
+    directory = parent;
+  }
+}
+
+/// Extracts channel method names, e.g. `channel#getTags`, from the Dart source.
+Set<String> _dartMethods(Directory lib) {
+  final pattern = RegExp(
+    '''["']([A-Za-z][A-Za-z0-9]*(?:#[A-Za-z][A-Za-z0-9]*)+)["']''',
+  );
+
+  return lib
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where((file) => file.path.endsWith(".dart"))
+      .expand(
+        (file) => pattern
+            .allMatches(file.readAsStringSync())
+            .map((match) => match.group(1)!),
+      )
+      .toSet();
+}
+
+/// Extracts the method names handled by a native plugin's method call switch.
+Set<String> _nativeMethods(File plugin, RegExp pattern) {
+  return pattern
+      .allMatches(plugin.readAsStringSync())
+      .map((match) => match.group(1)!)
+      .where((method) => method.contains("#"))
+      .toSet();
+}


### PR DESCRIPTION
### What do these changes do?

**Implements four method channel handlers that were missing on iOS.** The Dart layer invoked them, but `AirshipPlugin.swift` had no `case` for them, so each one failed at runtime with a `FlutterError(code: "UNAVAILABLE")`:

- `channel#enableChannelCreation`
- `featureFlagManager#resultCacheGetFlag`
- `featureFlagManager#resultCacheSetFlag`
- `featureFlagManager#resultCacheRemoveFlag`

`featureFlagManager#resultCacheGetFlag` was also missing on Android and has been added.

**Aligns `featureFlagManager.flag()` with the react-native plugin and the native SDKs** (behavior change, documented in `MIGRATION.md`):

- It no longer catches every error, prints it, and returns `null`. The return type is now `Future<FeatureFlag>` and a `PlatformException` propagates to the caller.
- `useResultCache` now defaults to `true` instead of `false`, in the Dart signature and in the Android fallback.

Two notes on the iOS implementations:

- `resultCacheSetFlag` receives the TTL in milliseconds from Dart (`ttl.inMilliseconds`) while the proxy's `cache(flag:ttl:)` takes a `TimeInterval` in seconds, so it divides by 1000 — the same conversion the react-native plugin does.
- The flag argument arrives as a JSON string (same as `trackInteraction`) and is decoded into a `FeatureFlagProxy`.

No version bump or CHANGELOG entry here — in this repo both are generated in the release commit by `scripts/update_version.sh` / `scripts/update_changelog.sh`.

### Why are these changes necessary?

The result cache APIs and `enableChannelCreation` were unusable on iOS — any app calling them got a platform exception. Silently returning `null` from `flag()` also made real failures (flags not downloaded yet, Airship not ready) indistinguishable from a flag that legitimately evaluated to nothing, and both defaults differed from every other Airship plugin.

### How did you verify these changes?

**Tests** — `flutter test`, 24 tests pass.

- `test/native_method_parity_test.dart` is the regression guard for this whole class of bug: it extracts every `foo#bar` method name invoked anywhere under `lib/`, extracts the handled cases from both `AirshipPlugin.swift` and `AirshipPlugin.kt`, and fails if a Dart-invoked method is unhandled on either platform. Platform-specific names (`#ios#`, `#android#`) and the iOS-only `liveActivity#*` set are excluded. Run against `main`, it fails with all four missing iOS methods listed.
- `test/airship_feature_flag_manager_test.dart` covers method names and arguments for all five feature flag APIs, the `useResultCache: true` default, the ms TTL, and that `flag()` throws on a platform error, on a missing plugin implementation, and on a null response.
- `test/airship_channel_test.dart` covers `enableChannelCreation`.

**Native compilation** — both plugins compile with the new code:

- iOS: `xcodebuild -workspace Runner.xcworkspace -scheme Runner -configuration Release -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build` → `BUILD SUCCEEDED`, with `AirshipPlugin.swift` compiled in the `airship_flutter` target.
- Android: `./gradlew :airship_flutter:compileReleaseKotlin` → `BUILD SUCCESSFUL`.

**Static analysis** — `flutter analyze` and `dart analyze --fatal-infos` clean at the repo root and in `example/`.

Not verified against a live Airship app on device — the four new iOS handlers are compile-checked and unit-tested at the channel boundary, but the proxy calls themselves have not been exercised against a real channel/flag.

### Anything else a reviewer should know?

`flag()` returning non-null is a breaking change for any caller doing `if (flag != null)`. The example app had exactly that dead null check and has been updated. `MIGRATION.md` gets a `12.5.x to 12.6.0` section with before/after snippets for both the throwing behavior and the `useResultCache` default, so the next release should be a minor bump.
